### PR TITLE
 Update kube.libsonnet for newer (1.8+) k8s

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,8 +17,20 @@ test: unittests lint parse validate diff
 unittests:
 	jsonnet $(UNITTEST_JSONNET)
 
-lint: lint-help
-	jsonnet fmt --test $(JSONNET_FMT) -- $(ALL_JSONNET) $(LIB_JSONNET)
+lint:
+	@set -e; errs=0; \
+        for f in $(ALL_JSONNET) $(LIB_JSONNET); do \
+	  if ! jsonnet fmt --test $(JSONNET_FMT) -- $$f; then \
+	    echo "FAILED lint: $$f" >&2; \
+	    errs=$$(( $$errs + 1 )); \
+	  fi; \
+	done; \
+	if [ $$errs -gt 0 ]; then \
+	  echo "NOTE: if the 'lint' target fails, run:"; \
+	  echo "      $(MAKE) fix-lint lint"; \
+	  exit 1; \
+	fi
+
 
 parse: $(PHONY_PARSE)
 
@@ -43,17 +55,13 @@ diff-help:
 	@echo "      $(MAKE) gen-golden diff"
 	@echo
 
-lint-help:
-	@echo "NOTE: if the 'lint' target fails, run:"
-	@echo "      $(MAKE) fix-lint lint"
-	@echo
-
 fix-lint:
-	@for f in $(ALL_JSONNET) $(LIB_JSONNET); do \
+	@set -e; \
+	for f in $(ALL_JSONNET) $(LIB_JSONNET); do \
 	  echo jsonnet fmt -i $(JSONNET_FMT) -- $$f; \
 	  jsonnet fmt -i $(JSONNET_FMT) -- $$f; \
 	done
 
 gen-golden: $(PHONY_GOLDEN)
 
-.PHONY: unittests lint parse validate diff %.parse %.diff golden/%.json diff-help lint-help fix-lint gen-golden
+.PHONY: unittests lint parse validate diff %.parse %.diff golden/%.json diff-help fix-lint gen-golden

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -49,7 +49,10 @@ lint-help:
 	@echo
 
 fix-lint:
-	jsonnet fmt -i $(JSONNET_FMT) -- $(ALL_JSONNET) $(LIB_JSONNET)
+	@for f in $(ALL_JSONNET) $(LIB_JSONNET); do \
+	  echo jsonnet fmt -i $(JSONNET_FMT) -- $$f; \
+	  jsonnet fmt -i $(JSONNET_FMT) -- $$f; \
+	done
 
 gen-golden: $(PHONY_GOLDEN)
 

--- a/tests/golden/test-simple-validate.json
+++ b/tests/golden/test-simple-validate.json
@@ -34,9 +34,13 @@
                "spec": {
                   "completions": 1,
                   "parallelism": 1,
+                  "selector": {
+                     "matchLabels": {
+                        "name": "foo-cronjob"
+                     }
+                  },
                   "template": {
                      "metadata": {
-                        "annotations": { },
                         "labels": {
                            "name": "foo-cronjob"
                         }
@@ -47,6 +51,7 @@
                               "args": [ ],
                               "env": [ ],
                               "image": "busybox",
+                              "imagePullPolicy": "IfNotPresent",
                               "name": "foo",
                               "ports": [ ],
                               "stdin": false,
@@ -55,6 +60,7 @@
                            }
                         ],
                         "imagePullSecrets": [ ],
+                        "initContainers": [ ],
                         "restartPolicy": "OnFailure",
                         "terminationGracePeriodSeconds": 30,
                         "volumes": [ ]
@@ -67,7 +73,7 @@
          }
       },
       {
-         "apiVersion": "extensions/v1beta1",
+         "apiVersion": "apps/v1beta2",
          "kind": "Deployment",
          "metadata": {
             "annotations": { },
@@ -80,7 +86,11 @@
          "spec": {
             "minReadySeconds": 30,
             "replicas": 1,
-            "revisionHistoryLimit": 10,
+            "selector": {
+               "matchLabels": {
+                  "name": "foo-deploy"
+               }
+            },
             "strategy": {
                "rollingUpdate": {
                   "maxSurge": "25%",
@@ -111,6 +121,7 @@
                            }
                         ],
                         "image": "nginx:1.12",
+                        "imagePullPolicy": "IfNotPresent",
                         "name": "foo",
                         "ports": [
                            {
@@ -134,6 +145,7 @@
                      }
                   ],
                   "imagePullSecrets": [ ],
+                  "initContainers": [ ],
                   "serviceAccountName": "foo-sa",
                   "terminationGracePeriodSeconds": 30,
                   "volumes": [
@@ -149,7 +161,7 @@
          }
       },
       {
-         "apiVersion": "extensions/v1beta1",
+         "apiVersion": "apps/v1beta2",
          "kind": "DaemonSet",
          "metadata": {
             "annotations": { },
@@ -160,6 +172,11 @@
             "namespace": "foons"
          },
          "spec": {
+            "selector": {
+               "matchLabels": {
+                  "name": "foo-ds"
+               }
+            },
             "template": {
                "metadata": {
                   "annotations": { },
@@ -183,6 +200,7 @@
                            }
                         ],
                         "image": "nginx:1.12",
+                        "imagePullPolicy": "IfNotPresent",
                         "name": "foo",
                         "ports": [
                            {
@@ -206,6 +224,7 @@
                      }
                   ],
                   "imagePullSecrets": [ ],
+                  "initContainers": [ ],
                   "terminationGracePeriodSeconds": 30,
                   "volumes": [
                      {
@@ -216,6 +235,12 @@
                      }
                   ]
                }
+            },
+            "updateStrategy": {
+               "rollingUpdate": {
+                  "maxUnavailable": 1
+               },
+               "type": "RollingUpdate"
             }
          }
       },
@@ -275,9 +300,13 @@
          "spec": {
             "completions": 1,
             "parallelism": 1,
+            "selector": {
+               "matchLabels": {
+                  "name": "foo-job"
+               }
+            },
             "template": {
                "metadata": {
-                  "annotations": { },
                   "labels": {
                      "name": "foo-job"
                   }
@@ -288,6 +317,7 @@
                         "args": [ ],
                         "env": [ ],
                         "image": "busybox",
+                        "imagePullPolicy": "IfNotPresent",
                         "name": "foo",
                         "ports": [ ],
                         "stdin": false,
@@ -296,6 +326,7 @@
                      }
                   ],
                   "imagePullSecrets": [ ],
+                  "initContainers": [ ],
                   "restartPolicy": "OnFailure",
                   "terminationGracePeriodSeconds": 30,
                   "volumes": [ ]
@@ -441,6 +472,7 @@
                      }
                   ],
                   "image": "nginx:1.12",
+                  "imagePullPolicy": "IfNotPresent",
                   "name": "foo",
                   "ports": [
                      {
@@ -464,6 +496,7 @@
                }
             ],
             "imagePullSecrets": [ ],
+            "initContainers": [ ],
             "terminationGracePeriodSeconds": 30,
             "volumes": [
                {
@@ -581,7 +614,7 @@
             "ports": [
                {
                   "port": 80,
-                  "targetPort": "http"
+                  "targetPort": 80
                }
             ],
             "selector": {
@@ -591,7 +624,7 @@
          }
       },
       {
-         "apiVersion": "apps/v1beta1",
+         "apiVersion": "apps/v1beta2",
          "kind": "StatefulSet",
          "metadata": {
             "annotations": { },
@@ -603,6 +636,11 @@
          },
          "spec": {
             "replicas": 1,
+            "selector": {
+               "matchLabels": {
+                  "name": "foo-sts"
+               }
+            },
             "serviceName": "foo-sts",
             "template": {
                "metadata": {
@@ -627,6 +665,7 @@
                            }
                         ],
                         "image": "nginx:1.12",
+                        "imagePullPolicy": "IfNotPresent",
                         "name": "foo",
                         "ports": [
                            {
@@ -654,6 +693,7 @@
                      }
                   ],
                   "imagePullSecrets": [ ],
+                  "initContainers": [ ],
                   "serviceAccountName": "foo-sa",
                   "terminationGracePeriodSeconds": 30,
                   "volumes": [
@@ -666,12 +706,15 @@
                   ]
                }
             },
+            "updateStrategy": {
+               "rollingUpdate": {
+                  "partition": 0
+               },
+               "type": "RollingUpdate"
+            },
             "volumeClaimTemplates": [
                {
-                  "apiVersion": "v1",
-                  "kind": "PersistentVolumeClaim",
                   "metadata": {
-                     "annotations": { },
                      "labels": {
                         "name": "datadir"
                      },

--- a/tests/unittests.jsonnet
+++ b/tests/unittests.jsonnet
@@ -25,8 +25,11 @@ std.assertEqual(kube.objectItems({ a: 1, b: 2 }), [["a", 1], ["b", 2]]) &&
 std.assertEqual(kube.hyphenate("foo_bar_baz"), ("foo-bar-baz")) &&
 std.assertEqual(kube.mapToNamedList({ foo: { a: "b" } }), [{ name: "foo", a: "b" }]) &&
 std.assertEqual(kube.filterMapByFields({ a: 1, b: 2, c: 3 }, ["a", "c", "d"]), { a: 1, c: 3 }) &&
+std.assertEqual(kube.parseOctal("755"), 493) &&
 std.assertEqual(kube.siToNum("42G"), 42 * 1e9) &&
 std.assertEqual(kube.siToNum("42Gi"), 42 * std.pow(2, 30)) &&
+std.assertEqual(kube.toUpper("ForTy 2"), "FORTY 2") &&
+std.assertEqual(kube.toLower("ForTy 2"), "forty 2") &&
 std.assertEqual(an_obj, {
   apiVersion: "v1",
   kind: "Gentle",


### PR DESCRIPTION
Many small diffs.

New features:
- Add `parseOctal` helper function (eg useful for volume `mode`).
- Add `toUpper` and `toLower`.
- Change `:` to `-` when preparing default `name` label (eg appears in
  system object names but is not safe in label keys).
- Add `host` and `host_colon_port` helpers to `Service`.
- Set container `imagePullPolicy` default explicitly (following usual
  k8s default logic). In particular this means the server-side value
  will be updated if the jsonnet image is updated to/from `:latest`.
- Add `PodDisruptionBudget`.
- "First container" logic now defaults to the container named
  `default` rather than _requiring_ a value for `default_container` in
  the multi-container case. `default_container` continues to override.
- Add container `initContainers_`, similar to `containers_`.
- `HostPathVolume` now takes an optional `type` for convenience and
  brevity.
- `ResourceFieldRef` now takes `divisor` as an optional arg rather
  than object field, for brevity.
- Set `selector` explicitly for `Deployment`, `StatefulSet`, `DaemonSet`.
- Provide an explicit `RollingUpdate` strategy for `StatefulSet` and
  `DaemonSet`.
- Add jsonnet `assert` for invalid (relative) paths in `Ingress`.

Changes to previous behaviour:
- Change default `_Object` `name` label to follow updates to
  `metadata.name` rather than continue to use original `_Object` arg.
- Change default `Service` `targetPort` to use target's (numeric)
  `containerPort` rather than (string) `name`.  `containerPort` is
  required, whereas `name` is optional.
- `Deployment` now uses `apps/v1beta2`, and non-default
  `revisionHistoryLimit` is removed (10 is now the server default)
- `StatefulSet` now uses `apps/v1beta2`.
- `DaemonSet` now uses `apps/v1beta2`.
- Slightly change workaround for StatefulSet non-semantic diff bug, to
  take advantage of `std.prune`.  May require explicitly restoring
  some of the previous "avoid-omitempty" workaround values for
  existing StatefulSets to avoid server-side validation error on
  updates.
- Changed `JobSpec` arg->override to match style of similar `PodSpec`.
- `CustomResourceDefinition` changed to take more useful "gvk" args.