### PR TITLE
Update the Ingress annotations

### DIFF
--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -68,7 +68,7 @@ local perCloudSvcSpec(cloud) = (
     },
     cert_external_metadata:: {
       annotations+: {
-        "certmanager.k8s.io/cluster-issuer": "letsencrypt-prod-http"
+        "certmanager.k8s.io/cluster-issuer": "letsencrypt-prod-http",
       },
     },
 

--- a/tests/golden/test-simple-validate.json
+++ b/tests/golden/test-simple-validate.json
@@ -249,12 +249,12 @@
          "kind": "Ingress",
          "metadata": {
             "annotations": {
-               "stable.k8s.psg.io/kcm.email": "sre@bitnami.com",
-               "stable.k8s.psg.io/kcm.provider": "route53"
+               "certmanager.k8s.io/acme-challenge-type": "dns01",
+               "certmanager.k8s.io/acme-dns01-provider": "default",
+               "certmanager.k8s.io/cluster-issuer": "letsencrypt-prod-dns"
             },
             "labels": {
-               "name": "foo-ingress",
-               "stable.k8s.psg.io/kcm.class": "default"
+               "name": "foo-ingress"
             },
             "name": "foo-ingress",
             "namespace": "foons"


### PR DESCRIPTION
We've replaced the KCM / Kube-lego cert providers with Certmanager. I've updated the annotations with the new ones.

This closes #6