### PR TITLE
bitnami.libsonnet: update to jetstack/cert-manager annotations

### DIFF
--- a/tests/golden/test-simple-validate.json
+++ b/tests/golden/test-simple-validate.json
@@ -249,12 +249,12 @@
          "kind": "Ingress",
          "metadata": {
             "annotations": {
-               "stable.k8s.psg.io/kcm.email": "sre@bitnami.com",
-               "stable.k8s.psg.io/kcm.provider": "route53"
+               "certmanager.k8s.io/acme-challenge-type": "dns01",
+               "certmanager.k8s.io/acme-dns01-provider": "default",
+               "certmanager.k8s.io/cluster-issuer": "letsencrypt-prod-dns"
             },
             "labels": {
-               "name": "foo-ingress",
-               "stable.k8s.psg.io/kcm.class": "default"
+               "name": "foo-ingress"
             },
             "name": "foo-ingress",
             "namespace": "foons"

--- a/tests/test-simple-validate.jsonnet
+++ b/tests/test-simple-validate.jsonnet
@@ -1,5 +1,5 @@
-local kube = import "../kube.libsonnet";
 local bitnami = import "../bitnami.libsonnet";
+local kube = import "../kube.libsonnet";
 
 local stack = {
   namespace:: "foons",


### PR DESCRIPTION
Followup from #7 by syncing it verbatim with internal one, closes #6.