### PR TITLE
[jjo] add args_format to kube.Container()

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -216,11 +216,27 @@
       for x in std.objectFields(map)
     ],
 
+    argFormat(kv, f):: (
+      if f.split then
+        [
+          "%s%s" % [f.prefix, kv[0]],
+          "%s" % [kv[1]],
+        ]
+      else
+        [
+          "%s%s=%s" % [f.prefix, kv[0], kv[1]],
+        ]
+    ),
+
     env_:: {},
     env: self.envList(self.env_),
 
+    args_format:: { prefix: "--", split: false },
     args_:: {},
-    args: ["--%s=%s" % kv for kv in $.objectItems(self.args_)],
+    args: std.flattenArrays([
+      self.argFormat(kv, self.args_format)
+      for kv in $.objectItems(self.args_)
+    ]),
 
     ports_:: {},
     ports: $.mapToNamedList(self.ports_),

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,18 +1,23 @@
-FROM debian:8
+FROM bitnami/minideb:stretch
 MAINTAINER sre@bitnami.com
 
-RUN adduser --home /home/user --disabled-password --gecos User user
+ARG jsonnet_version=0.11.2
+ARG kubectl_version=1.12.0
+ARG kubecfg_version=0.9.0
 
-RUN apt-get -q update && apt-get -qy install jq make
+RUN install_packages jq make curl ca-certificates
 
-ADD https://storage.googleapis.com/bitnami-jenkins-tools/jsonnet-0.9.5 /usr/local/bin/jsonnet
+RUN curl -sLo /usr/local/bin/jsonnet https://storage.googleapis.com/bitnami-jenkins-tools/jsonnet-${jsonnet_version}
+
 RUN chmod +x /usr/local/bin/jsonnet
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+RUN curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/amd64/kubectl
 RUN chmod +x /usr/local/bin/kubectl
 
-ADD https://github.com/ksonnet/kubecfg/releases/download/v0.7.2/kubecfg-linux-amd64 /usr/local/bin/kubecfg
+RUN curl -sLo /usr/local/bin/kubecfg https://github.com/ksonnet/kubecfg/releases/download/v${kubecfg_version}/kubecfg-linux-amd64
 RUN chmod +x /usr/local/bin/kubecfg
+
+RUN adduser --home /home/user --disabled-password --gecos User user
 
 USER user
 WORKDIR /home/user

--- a/tests/unittests.jsonnet
+++ b/tests/unittests.jsonnet
@@ -4,14 +4,35 @@ local an_obj = kube._Object("v1", "Gentle", "foo");
 local a_pod = kube.Pod("foo") {
   metadata+: { labels+: { foo: "bar", bar: "qxx" } },
   spec+: {
+    default_container: "c1",
     containers_+: {
-      foo: kube.Container("foo") {
+      local c = self,
+      c1: kube.Container("c1") {
         image: "nginx",
+        args_: {
+          k1: "v1",
+          k2: "v2",
+        },
         ports_: {
           http: { containerPort: 8080 },
           https: { containerPort: 8443 },
           udp: { containerPort: 5353, protocol: "UDP" },
         },
+      },
+      c2: kube.Container("c2") {
+        image: "nginx",
+        args_format+: { prefix: "-" },
+        args_: c.c1.args_,
+      },
+      c3: kube.Container("c3") {
+        image: "nginx",
+        args_format+: { split: true },
+        args_: c.c1.args_,
+      },
+      c4: kube.Container("c4") {
+        image: "nginx",
+        args_format+: { prefix: "-", split: true },
+        args_: c.c1.args_,
       },
     },
   },
@@ -20,6 +41,10 @@ local a_deploy = kube.Deployment("foo") {
   spec+: { template+: { metadata+: a_pod.metadata, spec+: a_pod.spec } },
 };
 // Basic unittesting for methods that are not exercised by the other e2e-ish tests
+std.assertEqual(a_pod.spec.containers[0].args, ["--k1=v1", "--k2=v2"]) &&
+std.assertEqual(a_pod.spec.containers[1].args, ["-k1=v1", "-k2=v2"]) &&
+std.assertEqual(a_pod.spec.containers[2].args, ["--k1", "v1", "--k2", "v2"]) &&
+std.assertEqual(a_pod.spec.containers[3].args, ["-k1", "v1", "-k2", "v2"]) &&
 std.assertEqual(kube.objectValues({ a: 1, b: 2 }), [1, 2]) &&
 std.assertEqual(kube.objectItems({ a: 1, b: 2 }), [["a", 1], ["b", 2]]) &&
 std.assertEqual(kube.hyphenate("foo_bar_baz"), ("foo-bar-baz")) &&


### PR DESCRIPTION
Add `args_format` to allow overriding args[] generation
as per below example.

Given args_: {'k': 'v'}:
  (default, current behavior)               => args: ['--k=v']
  args_format+: {prefix: '-'}               => args: ['-k=v']
  args_format+: {split: true }              => args: ['--k', 'v']
  args_format+: {prefix: '-', split: true } => args: ['-k', 'v']

Fixes #12.