### PR TITLE
Use "app" label in selectors

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -122,6 +122,12 @@
     },
   },
 
+  _AppObject(apiVersion, kind, name):: $._Object(apiVersion, kind, name) {
+    metadata+: {
+      labels+: { app: name },
+    },
+  },
+
   List(): {
     apiVersion: "v1",
     kind: "List",
@@ -160,7 +166,7 @@
     },
 
     spec: {
-      selector: service.target_pod.metadata.labels,
+      selector: { app: service.target_pod.metadata.labels.app },
       ports: [
         {
           port: service.port,
@@ -239,12 +245,12 @@
     spec: {
       minAvailable: 1,
       selector: {
-        matchLabels: this.target_pod.metadata.labels,
+        matchLabels: { app: this.target_pod.metadata.labels.app },
       },
     },
   },
 
-  Pod(name): $._Object("v1", "Pod", name) {
+  Pod(name): $._AppObject("v1", "Pod", name) {
     spec: $.PodSpec,
   },
 
@@ -370,7 +376,7 @@
     },
   },
 
-  Deployment(name): $._Object("apps/v1beta2", "Deployment", name) {
+  Deployment(name): $._AppObject("apps/v1beta2", "Deployment", name) {
     local deployment = self,
 
     spec: {
@@ -383,7 +389,7 @@
       },
 
       selector: {
-        matchLabels: deployment.spec.template.metadata.labels,
+        matchLabels: { app: deployment.spec.template.metadata.labels.app },
       },
 
       strategy: {
@@ -438,7 +444,7 @@
     },
   },
 
-  StatefulSet(name): $._Object("apps/v1beta2", "StatefulSet", name) {
+  StatefulSet(name): $._AppObject("apps/v1beta2", "StatefulSet", name) {
     local sset = self,
 
     spec: {
@@ -460,7 +466,7 @@
       },
 
       selector: {
-        matchLabels: sset.spec.template.metadata.labels,
+        matchLabels: { app: sset.spec.template.metadata.labels.app },
       },
 
       volumeClaimTemplates_:: {},
@@ -478,7 +484,7 @@
     },
   },
 
-  Job(name): $._Object("batch/v1", "Job", name) {
+  Job(name): $._AppObject("batch/v1", "Job", name) {
     local job = self,
 
     spec: $.JobSpec {
@@ -491,7 +497,7 @@
   },
 
   // NB: kubernetes >= 1.8.x has batch/v1beta1 (olders were batch/v2alpha1)
-  CronJob(name): $._Object("batch/v1beta1", "CronJob", name) {
+  CronJob(name): $._AppObject("batch/v1beta1", "CronJob", name) {
     local cronjob = self,
 
     spec: {
@@ -523,14 +529,14 @@
     },
 
     selector: {
-      matchLabels: this.template.metadata.labels,
+      matchLabels: { app: this.template.metadata.labels.app },
     },
 
     completions: 1,
     parallelism: 1,
   },
 
-  DaemonSet(name): $._Object("apps/v1beta2", "DaemonSet", name) {
+  DaemonSet(name): $._AppObject("apps/v1beta2", "DaemonSet", name) {
     local ds = self,
     spec: {
       updateStrategy: {
@@ -548,7 +554,7 @@
       },
 
       selector: {
-        matchLabels: ds.spec.template.metadata.labels,
+        matchLabels: { app: ds.spec.template.metadata.labels.app },
       },
     },
   },
@@ -666,7 +672,7 @@
     podSelector: std.prune({
       matchLabels:
         if filter != null then $.filterMapByFields($.podRef(obj).metadata.labels, filter)
-        else $.podRef(obj).metadata.labels,
+        else { app: $.podRef(obj).metadata.labels.app },
     }),
   },
 

--- a/tests/golden/test-simple-validate.json
+++ b/tests/golden/test-simple-validate.json
@@ -22,6 +22,7 @@
          "metadata": {
             "annotations": { },
             "labels": {
+               "app": "foo-cronjob",
                "name": "foo-cronjob"
             },
             "name": "foo-cronjob",
@@ -36,12 +37,13 @@
                   "parallelism": 1,
                   "selector": {
                      "matchLabels": {
-                        "name": "foo-cronjob"
+                        "app": "foo-cronjob"
                      }
                   },
                   "template": {
                      "metadata": {
                         "labels": {
+                           "app": "foo-cronjob",
                            "name": "foo-cronjob"
                         }
                      },
@@ -78,6 +80,7 @@
          "metadata": {
             "annotations": { },
             "labels": {
+               "app": "foo-deploy",
                "name": "foo-deploy"
             },
             "name": "foo-deploy",
@@ -88,7 +91,7 @@
             "replicas": 1,
             "selector": {
                "matchLabels": {
-                  "name": "foo-deploy"
+                  "app": "foo-deploy"
                }
             },
             "strategy": {
@@ -102,6 +105,7 @@
                "metadata": {
                   "annotations": { },
                   "labels": {
+                     "app": "foo-deploy",
                      "name": "foo-deploy"
                   }
                },
@@ -166,6 +170,7 @@
          "metadata": {
             "annotations": { },
             "labels": {
+               "app": "foo-ds",
                "name": "foo-ds"
             },
             "name": "foo-ds",
@@ -174,13 +179,14 @@
          "spec": {
             "selector": {
                "matchLabels": {
-                  "name": "foo-ds"
+                  "app": "foo-ds"
                }
             },
             "template": {
                "metadata": {
                   "annotations": { },
                   "labels": {
+                     "app": "foo-ds",
                      "name": "foo-ds"
                   }
                },
@@ -292,6 +298,7 @@
          "metadata": {
             "annotations": { },
             "labels": {
+               "app": "foo-job",
                "name": "foo-job"
             },
             "name": "foo-job",
@@ -302,12 +309,13 @@
             "parallelism": 1,
             "selector": {
                "matchLabels": {
-                  "name": "foo-job"
+                  "app": "foo-job"
                }
             },
             "template": {
                "metadata": {
                   "labels": {
+                     "app": "foo-job",
                      "name": "foo-job"
                   }
                },
@@ -390,7 +398,7 @@
                      {
                         "podSelector": {
                            "matchLabels": {
-                              "name": "foo-sts"
+                              "app": "foo-sts"
                            }
                         }
                      }
@@ -403,14 +411,14 @@
                      {
                         "podSelector": {
                            "matchLabels": {
-                              "name": "foo-job"
+                              "app": "foo-job"
                            }
                         }
                      },
                      {
                         "podSelector": {
                            "matchLabels": {
-                              "name": "foo-cronjob"
+                              "app": "foo-cronjob"
                            }
                         }
                      },
@@ -436,7 +444,7 @@
             ],
             "podSelector": {
                "matchLabels": {
-                  "name": "foo-deploy"
+                  "app": "foo-deploy"
                }
             },
             "policyTypes": [
@@ -451,6 +459,7 @@
          "metadata": {
             "annotations": { },
             "labels": {
+               "app": "foo-pod",
                "name": "foo-pod"
             },
             "name": "foo-pod",
@@ -618,7 +627,7 @@
                }
             ],
             "selector": {
-               "name": "foo-deploy"
+               "app": "foo-deploy"
             },
             "type": "ClusterIP"
          }
@@ -629,6 +638,7 @@
          "metadata": {
             "annotations": { },
             "labels": {
+               "app": "foo-sts",
                "name": "foo-sts"
             },
             "name": "foo-sts",
@@ -638,7 +648,7 @@
             "replicas": 1,
             "selector": {
                "matchLabels": {
-                  "name": "foo-sts"
+                  "app": "foo-sts"
                }
             },
             "serviceName": "foo-sts",
@@ -646,6 +656,7 @@
                "metadata": {
                   "annotations": { },
                   "labels": {
+                     "app": "foo-sts",
                      "name": "foo-sts"
                   }
                },

--- a/tests/unittests.jsonnet
+++ b/tests/unittests.jsonnet
@@ -50,5 +50,5 @@ std.assertEqual(
 ) &&
 std.assertEqual(
   kube.podLabelsSelector(a_deploy),
-  { podSelector: { matchLabels: { name: "foo", foo: "bar", bar: "qxx" } } }
+  { podSelector: { matchLabels: { app: "foo" } } }
 )


### PR DESCRIPTION
Fixes issue #16 - Deployment's selector should be immutable

Scenario:
- Deployment is created with kube.libsonnet, CI process adds additional labels
  e.g. "ci-job-id"
- Deployment is updated with the same process but the CI process was updated to
  add new label e.g. "ci-cluster"
- kubectl apply fails as the selector field is immutable

This adds an additional label "app" to Pod, Deployment, StatefulSet, DaemonSet,
Job and CronJob objects and use it when those objects needs to be referred by
selectors.