### PR TITLE
Removes replicas assert

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -413,7 +413,7 @@
       minReadySeconds: 30,
 
       replicas: 1,
-      assert self.replicas >= 1,
+      assert self.replicas >= 0,
     },
   },
 

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -372,6 +372,7 @@
 
   Deployment(name): $._Object("apps/v1beta2", "Deployment", name) {
     local deployment = self,
+    hide_replicas:: false,
 
     spec: {
       template: {
@@ -412,8 +413,8 @@
       // NB: Upstream default is 0
       minReadySeconds: 30,
 
-      replicas: 1,
-      assert self.replicas >= 0,
+      [ if ! deployment.hide_replicas then "replicas" ]: 1,
+      assert if std.objectHas(self, "replicas") then self.replicas >= 0 else true,
     },
   },
 

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -372,7 +372,6 @@
 
   Deployment(name): $._Object("apps/v1beta2", "Deployment", name) {
     local deployment = self,
-    hide_replicas:: false,
 
     spec: {
       template: {
@@ -413,8 +412,7 @@
       // NB: Upstream default is 0
       minReadySeconds: 30,
 
-      [ if ! deployment.hide_replicas then "replicas" ]: 1,
-      assert if std.objectHas(self, "replicas") then self.replicas >= 0 else true,
+      replicas: 1,
     },
   },
 


### PR DESCRIPTION
First of all, thanks for the great library! We are using it in dozens of applications at Ecosia.org, and have built lots of whole application presets on top.

In some cases, we manually scale down deployments to zero replicas. I think it's totally valid to have the assert on the `replicas` field, but zero is also a valid value.

Also, we use the HPA to autoscale, and including the `replicas` field when using an HPA can lead to weird behaviour (see https://github.com/kubernetes/kubernetes/issues/25238). I added here a `hide_replicas` hidden field to the deploy spec, which will remote the `replicas` key from the spec (open to suggestions on a better way to do that - but I wanted to make it backwards-compatible for anyone who relies on the default being `replicas: 1`).