### PR TITLE
Update to require min k8s 1.9

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -53,6 +53,13 @@
 // (client-side, and gives better line information).
 
 {
+  // resource contructors will use kinds/versions/fields compatible at least with version:
+  minKubeVersion: {
+    major: 1,
+    minor: 9,
+    version: "%s.%s" % [self.major, self.minor],
+  },
+
   // Returns array of values from given object.  Does not include hidden fields.
   objectValues(o):: [o[field] for field in std.objectFields(o)],
 
@@ -370,7 +377,7 @@
     },
   },
 
-  Deployment(name): $._Object("apps/v1beta2", "Deployment", name) {
+  Deployment(name): $._Object("apps/v1", "Deployment", name) {
     local deployment = self,
 
     spec: {
@@ -437,7 +444,7 @@
     },
   },
 
-  StatefulSet(name): $._Object("apps/v1beta2", "StatefulSet", name) {
+  StatefulSet(name): $._Object("apps/v1", "StatefulSet", name) {
     local sset = self,
 
     spec: {
@@ -525,7 +532,7 @@
     parallelism: 1,
   },
 
-  DaemonSet(name): $._Object("apps/v1beta2", "DaemonSet", name) {
+  DaemonSet(name): $._Object("apps/v1", "DaemonSet", name) {
     local ds = self,
     spec: {
       updateStrategy: {

--- a/tests/golden/test-simple-validate.json
+++ b/tests/golden/test-simple-validate.json
@@ -68,7 +68,7 @@
          }
       },
       {
-         "apiVersion": "apps/v1beta2",
+         "apiVersion": "apps/v1",
          "kind": "Deployment",
          "metadata": {
             "annotations": { },
@@ -156,7 +156,7 @@
          }
       },
       {
-         "apiVersion": "apps/v1beta2",
+         "apiVersion": "apps/v1",
          "kind": "DaemonSet",
          "metadata": {
             "annotations": { },
@@ -614,7 +614,7 @@
          }
       },
       {
-         "apiVersion": "apps/v1beta2",
+         "apiVersion": "apps/v1",
          "kind": "StatefulSet",
          "metadata": {
             "annotations": { },


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#deprecations-and-removals
mentions:

```
DaemonSet, Deployment, and ReplicaSet resources will no longer be served from extensions/v1beta1, apps/v1beta1, or apps/v1beta2 in v1.16. Migrate to the apps/v1 API, available since v1.9. Existing persisted data can be retrieved via the apps/v1 API.
```

Also added the minimum supported version in the kube.libsonnet excplicitly.