### PR TITLE
Fixed missing `storageClassName` field in PersistentVolumeClaim's `spec`

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -203,6 +203,7 @@
         },
       },
       accessModes: ["ReadWriteOnce"],
+      [if pvc.storageClass != null then 'storageClassName']: pvc.storageClass,
     },
   },
 

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -203,7 +203,7 @@
         },
       },
       accessModes: ["ReadWriteOnce"],
-      [if pvc.storageClass != null then 'storageClassName']: pvc.storageClass,
+      [if pvc.storageClass != null then "storageClassName"]: pvc.storageClass,
     },
   },
 


### PR DESCRIPTION
Fix #25

As reported in [the official Kubernetes docs](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class):

> A PV can have a class, which is specified by setting the storageClassName attribute to the name of a StorageClass. A PV of a particular class can only be bound to PVCs requesting that class. A PV with no storageClassName has no class and can only be bound to PVCs that request no particular class.

> In the past, the annotation `volume.beta.kubernetes.io/storage-class` was used instead of the `storageClassName` attribute. This annotation is still working, however it will become fully deprecated in a future Kubernetes release

