### PR TITLE
[jjo] v1.16 Ingress apiVersion and other fixes

### DIFF
--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -1,5 +1,5 @@
 // Generic stuff is in kube.libsonnet - this file contains
-// additional AWS or Bitnami -specific conventions.
+// bitnami-specific conventions.
 
 local kube = import "kube.libsonnet";
 
@@ -92,8 +92,6 @@ local perCloudSvcSpec(cloud) = (
         {
           hosts: std.set([r.host for r in ing.spec.rules]),
           secretName: ing.secretName,
-
-          assert std.length(self.hosts) <= 1 : "kube-cert-manager only supports one host per secret - make a separate Ingress resource",
         },
       ],
 

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -420,6 +420,9 @@
       // NB: Upstream default is 0
       minReadySeconds: 30,
 
+      // NB: Regular k8s default is to keep all revisions
+      revisionHistoryLimit: 10,
+
       replicas: 1,
     },
   },
@@ -556,7 +559,7 @@
     },
   },
 
-  Ingress(name): $._Object("extensions/v1beta1", "Ingress", name) {
+  Ingress(name): $._Object("networking.k8s.io/v1beta1", "Ingress", name) {
     spec: {},
 
     local rel_paths = [
@@ -700,6 +703,7 @@
       ingress_:: {},
       egress: $.objectValues(self.egress_),
       egress_:: {},
+      podSelector: {},
     },
   },
 }

--- a/tests/golden/test-simple-validate.json
+++ b/tests/golden/test-simple-validate.json
@@ -81,6 +81,7 @@
          "spec": {
             "minReadySeconds": 30,
             "replicas": 1,
+            "revisionHistoryLimit": 10,
             "selector": {
                "matchLabels": {
                   "name": "foo-deploy"
@@ -240,7 +241,7 @@
          }
       },
       {
-         "apiVersion": "extensions/v1beta1",
+         "apiVersion": "networking.k8s.io/v1beta1",
          "kind": "Ingress",
          "metadata": {
             "annotations": {


### PR DESCRIPTION
* bitnami.libsonnet: sync from internal (working, prod) repo
* kube.libsonnet:
  - also add v1.16 Ingress apiVersio
  - cap Deployment revisionHistoryLimit to 10
  - NetworkPolicy: add required podSelector field