### PR TITLE
[jjo] rollback Ingress apiVersion, better testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,30 +2,10 @@
 # trimmed down to only run lib testing.
 #
 # Provides 'test' target.  Uses docker.
+all:
+	@echo make tests
 
-UID := $(shell id -u)
-GID := $(shell id -g)
+tests:
+	make -C tests
 
-# Eg: if you need sudo, run with DOCKER_PREFIX=sudo
-DOCKER_PREFIX =
-
-DOCKER = $(DOCKER_PREFIX) docker
-DOCKER_BUILD = $(DOCKER) build --build-arg http_proxy=$(http_proxy)
-DOCKER_RUN = $(DOCKER) run --rm --network=host -u $(UID):$(GID) \
- -v $(CURDIR):$(CURDIR) -w $(CURDIR) \
- -v $(HOME)/.kube/config:/kubeconfig \
- -v $(HOME)/.kube/cache:/home/user/.kube/cache \
- -e TERM=$(TERM) -e KUBECONFIG=/kubeconfig
-
-all: tests
-
-docker-kube-manifests: tests/Dockerfile
-	if [ -z "$(shell $(DOCKER) images -q kube-manifests)" ]; then \
-	  $(DOCKER_BUILD) -t kube-manifests tests; \
-	fi
-
-tests: docker-kube-manifests
-	$(DOCKER_RUN) kube-manifests make -C tests
-
-
-.PHONY: all build test docker-kube-manifests
+.PHONY: all tests

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ a git submodule, i.e.:
 
 ## Testing
 
-Unit and e2e-ish testing exists at tests/, needs installed `jsonnet`
-and `kubecfg` binaries, as well as a working kubernetes configured
-environment for `kubecfg validate` against kubernetes API endpoint.
+Unit and e2e-ish testing at tests/, needs usable `docker-compose`
+at node, will run a `k3s` "dummy" container to serve Kube API, enough
+to for `kubecfg validate` against it:
 
-Above has some basic Travis CI integration (minikube API still WIP),
-that exercises unit and golden tests.
+    make tests
+
+If you don't want that full kube-api stack (will then use your "local"
+kubernetes configured environment), you can run:
+
+    make -C tests test-srcs test-kube

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -559,7 +559,7 @@
     },
   },
 
-  Ingress(name): $._Object("networking.k8s.io/v1beta1", "Ingress", name) {
+  Ingress(name): $._Object("extensions/v1beta1", "Ingress", name) {
     spec: {},
 
     local rel_paths = [

--- a/tests/.env
+++ b/tests/.env
@@ -6,3 +6,4 @@
 # You can override with e.g.
 # K3S_VERSION=v0.9.1 make tests
 K3S_VERSION=v0.3.0
+USERID=1000

--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,8 @@
+# As of Sept/2019, kube-api: k3s-release
+# - v1.13: v0.3.x
+# - v1.14: v0.4.x to v0.8.x
+# - v1.15: v0.9.x
+#
+# You can override with e.g.
+# K3S_VERSION=v0.9.1 make tests
+K3S_VERSION=v0.3.0

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,12 +1,12 @@
-FROM debian:8
+FROM bitnami/minideb:buster
 MAINTAINER sre@bitnami.com
 
 ARG jsonnet_version=0.14.0
 ARG kubectl_version=v1.13.0
 ARG kubecfg_version=v0.12.0
 
+RUN install_packages jq make curl ca-certificates
 RUN adduser --home /home/user --disabled-password --gecos User user
-RUN apt-get -q update && apt-get -qy install jq make curl
 
 RUN curl -sLo /tmp/jsonnet-v${jsonnet_version}.tar.gz https://github.com/google/jsonnet/releases/download/v${jsonnet_version}/jsonnet-bin-v${jsonnet_version}-linux.tar.gz
 RUN tar -zxf /tmp/jsonnet-v${jsonnet_version}.tar.gz -C /tmp && mv /tmp/jsonnet /tmp/jsonnetfmt /usr/local/bin

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,17 +1,20 @@
 FROM debian:8
 MAINTAINER sre@bitnami.com
 
+ARG jsonnet_version=0.14.0
+ARG kubectl_version=v1.13.0
+ARG kubecfg_version=v0.12.0
+
 RUN adduser --home /home/user --disabled-password --gecos User user
+RUN apt-get -q update && apt-get -qy install jq make curl
 
-RUN apt-get -q update && apt-get -qy install jq make
+RUN curl -sLo /tmp/jsonnet-v${jsonnet_version}.tar.gz https://github.com/google/jsonnet/releases/download/v${jsonnet_version}/jsonnet-bin-v${jsonnet_version}-linux.tar.gz
+RUN tar -zxf /tmp/jsonnet-v${jsonnet_version}.tar.gz -C /tmp && mv /tmp/jsonnet /tmp/jsonnetfmt /usr/local/bin
 
-ADD https://storage.googleapis.com/bitnami-jenkins-tools/jsonnet-0.9.5 /usr/local/bin/jsonnet
-RUN chmod +x /usr/local/bin/jsonnet
-
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+RUN curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/amd64/kubectl
 RUN chmod +x /usr/local/bin/kubectl
 
-ADD https://github.com/ksonnet/kubecfg/releases/download/v0.7.2/kubecfg-linux-amd64 /usr/local/bin/kubecfg
+RUN curl -sLo /usr/local/bin/kubecfg https://github.com/bitnami/kubecfg/releases/download/${kubecfg_version}/kubecfg-linux-amd64
 RUN chmod +x /usr/local/bin/kubecfg
 
 USER user

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,7 +20,11 @@ tests: docker-compose-tests
 docker-compose-tests:
 	install -d $(TMP_RANCHER) $(TMP_RANCHER)/etc && touch $(TMP_RANCHER)/etc/k3s.yaml
 	docker-compose -p $(PROJECT) up -d
-	rc=$$(timeout 60s docker wait $(DOCKER_E2E)) || rc=255 ; docker logs $(DOCKER_E2E); docker-compose -p $(PROJECT) down; exit $$rc
+	rc=$$(timeout 60s docker wait $(DOCKER_E2E)) || rc=255 ;\
+	   test $$rc -ne 0 && docker logs k3s-api;\
+	   docker logs $(DOCKER_E2E);\
+	   docker-compose -p $(PROJECT) down;\
+	   exit $$rc
 	rm -rf ./$(TMP_RANCHER)
 
 test-srcs: unittests lint parse diff

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,7 +20,7 @@ tests: docker-compose-tests
 docker-compose-tests:
 	install -d $(TMP_RANCHER) $(TMP_RANCHER)/etc && touch $(TMP_RANCHER)/etc/k3s.yaml
 	docker-compose -p $(PROJECT) up -d
-	rc=$$(docker wait $(DOCKER_E2E)); docker logs $(DOCKER_E2E); docker-compose -p $(PROJECT) down; exit $$rc
+	rc=$$(timeout 60s docker wait $(DOCKER_E2E)) || rc=255 ; docker logs $(DOCKER_E2E); docker-compose -p $(PROJECT) down; exit $$rc
 	rm -rf ./$(TMP_RANCHER)
 
 test-srcs: unittests lint parse diff

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,7 +19,7 @@ tests: docker-compose-tests
 
 docker-compose-tests:
 	install -d $(TMP_RANCHER) $(TMP_RANCHER)/etc && touch $(TMP_RANCHER)/etc/k3s.yaml
-	docker-compose -p $(PROJECT) up -d
+	USERID=$$(id -u) docker-compose -p $(PROJECT) up -d
 	rc=$$(timeout 60s docker wait $(DOCKER_E2E)) || rc=255 ;\
 	   test $$rc -ne 0 && docker logs k3s-api;\
 	   docker logs $(DOCKER_E2E);\

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,7 +10,21 @@ PHONY_GOLDEN=$(patsubst %.jsonnet,golden/%.json,$(ALL_JSONNET))
 PHONY_DIFF=$(patsubst %.jsonnet,%.diff,$(ALL_JSONNET))
 PHONY_PARSE=$(patsubst %.jsonnet,%.parse,$(ALL_JSONNET))
 
-test: unittests lint parse validate diff
+## These need to be in-sync with docker-compose.yaml
+DOCKER_E2E=e2e-test
+TMP_RANCHER=./tmp-rancher
+PROJECT=kubelibsonnet
+
+tests: docker-compose-tests
+
+docker-compose-tests:
+	install -d $(TMP_RANCHER) $(TMP_RANCHER)/etc && touch $(TMP_RANCHER)/etc/k3s.yaml
+	docker-compose -p $(PROJECT) up -d
+	rc=$$(docker wait $(DOCKER_E2E)); docker logs $(DOCKER_E2E); docker-compose -p $(PROJECT) down; exit $$rc
+	rm -rf ./$(TMP_RANCHER)
+
+test-srcs: unittests lint parse diff
+test-kube: validate
 
 # NB: unittest jsonnet files are also covered by parse and diff targets,
 #     called out here for convenience
@@ -20,7 +34,7 @@ unittests:
 lint:
 	@set -e; errs=0; \
         for f in $(ALL_JSONNET) $(LIB_JSONNET); do \
-	  if ! jsonnet fmt --test $(JSONNET_FMT) -- $$f; then \
+	  if ! jsonnetfmt --test $(JSONNET_FMT) -- $$f; then \
 	    echo "FAILED lint: $$f" >&2; \
 	    errs=$$(( $$errs + 1 )); \
 	  fi; \
@@ -31,15 +45,14 @@ lint:
 	  exit 1; \
 	fi
 
-
 parse: $(PHONY_PARSE)
+
+diff: diff-help $(PHONY_DIFF)
 
 validate:
 	timeout 10 kubectl api-versions > /dev/null \
 	|| { echo "WARNING: no usable runtime kube context, skipping."; exit 0 ;} \
-	&& kubecfg validate $(ALL_K8S_VALIDATE_JSONNET)
-
-diff: diff-help $(PHONY_DIFF)
+	&& kubectl version --short && kubecfg version && kubecfg validate --ignore-unknown=false $(ALL_K8S_VALIDATE_JSONNET)
 
 %.diff: %.jsonnet
 	diff -u golden/$(*).json <(jsonnet $(<))
@@ -58,8 +71,8 @@ diff-help:
 fix-lint:
 	@set -e; \
 	for f in $(ALL_JSONNET) $(LIB_JSONNET); do \
-	  echo jsonnet fmt -i $(JSONNET_FMT) -- $$f; \
-	  jsonnet fmt -i $(JSONNET_FMT) -- $$f; \
+	  echo jsonnetfmt -i $(JSONNET_FMT) -- $$f; \
+	  jsonnetfmt -i $(JSONNET_FMT) -- $$f; \
 	done
 
 gen-golden: $(PHONY_GOLDEN)

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -1,0 +1,49 @@
+version: "3"
+services:
+  kube-api:
+    image: rancher/k3s:${K3S_VERSION}
+    command: server --disable-agent
+    container_name: k3s-api
+    volumes:
+      - ./tmp-rancher:/.kube
+      - ./tmp-rancher:/.rancher
+      - ./tmp-rancher/etc:/etc/rancher/k3s
+    expose:
+      - 6443
+    user: "1000"
+    environment:
+      - USER=nobody
+      - HOME=/
+  e2e-test:
+    build: .
+    container_name: e2e-test
+    links:
+      - "kube-api:kube-api"
+    depends_on:
+      - kube-api
+    volumes:
+      - ./tmp-rancher:/tmp/rancher
+      - ..:/work
+    working_dir: /work
+    environment:
+      - HOME=/
+    user: "1000"
+    command:
+      - bash
+      - -c
+      - |
+        echo "INFO: Starting tests: unit, lint ..."
+        make -C tests test-srcs
+        export KUBECONFIG=/tmp/kubeconfig
+        echo "INFO: Waiting for kube-api to be available ..."
+        until kubectl get nodes; do
+          sleep 1
+          # Found that k3s releases create k3s.yaml under diff paths,
+          # redirecting stderr just to avoid red-herrings errors
+          sed -e s/localhost/kube-api/ -e s/127.0.0.1/kube-api/ \
+            /tmp/rancher/k3s.yaml /tmp/rancher/etc/k3s.yaml \
+            > $$KUBECONFIG 2>/dev/null
+        done
+        echo "INFO: Starting tests: validate ..."
+        set -x
+        make -C tests test-kube

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - ./tmp-rancher/etc:/etc/rancher/k3s
     expose:
       - 6443
-    user: "1000"
+    user: "${USERID}"
     environment:
       - USER=nobody
       - HOME=/
@@ -27,7 +27,7 @@ services:
     working_dir: /work
     environment:
       - HOME=/
-    user: "1000"
+    user: "${USERID}"
     command:
       - bash
       - -c

--- a/tests/golden/test-simple-validate.json
+++ b/tests/golden/test-simple-validate.json
@@ -241,7 +241,7 @@
          }
       },
       {
-         "apiVersion": "networking.k8s.io/v1beta1",
+         "apiVersion": "extensions/v1beta1",
          "kind": "Ingress",
          "metadata": {
             "annotations": {


### PR DESCRIPTION
* rollback Ingress apiVersion to extensions/v1beta1
  for wider kubeapi versions support:
  - networking.k8s.io/v1beta1: only available since v1.14
  - extensions/v1beta1: available until v1.20
* add docker-compose'd e2e testing via k3s dummy container
  for kube-api serving defaulting to v1.13, would have caught
  #27 issue as noted at #22