### PR TITLE
[jjo] add VerticalPodAutoscaler, adjust e2e-tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/golden/* linguist-generated

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ a git submodule, i.e.:
 ## Testing
 
 Unit and e2e-ish testing at tests/, needs usable `docker-compose`
-at node, will run a `k3s` "dummy" container to serve Kube API, enough
-to for `kubecfg validate` against it:
+setup at node, will run a `k3s` "dummy" container to serve Kube API,
+"enough" to run `kubecfg validate` against it:
 
     make tests
 
 If you don't want that full kube-api stack (will then use your "local"
 kubernetes configured environment), you can run:
 
-    make -C tests test-srcs test-kube
+    make -C tests local-tests kube-validate

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -706,4 +706,34 @@
       podSelector: {},
     },
   },
+
+  VerticalPodAutoscaler(name):: $._Object("autoscaling.k8s.io/v1beta2", "VerticalPodAutoscaler", name) {
+    spec: {
+      local spec = self,
+      targetRef_:: null,
+      targetRef: if spec.targetRef_ != null then {
+        apiVersion: spec.targetRef_.apiVersion,
+        kind: spec.targetRef_.kind,
+        name: spec.targetRef_.metadata.name,
+      } else {},
+      updatePolicy: {
+        updateMode: "Auto",
+      },
+      assert self.targetRef != {} : "VerticalPodAutoscaler: must set a targetRef",
+    },
+  },
+  // Helper function to ease VPA creation as e.g.:
+  // foo_vpa:: kube.createVPAFor($.foo_deploy)
+  createVPAFor(target, mode="Auto"):: $.VerticalPodAutoscaler(target.metadata.name) {
+    metadata+: {
+      namespace: target.metadata.namespace,
+      labels+: target.metadata.labels,
+    },
+    spec+: {
+      targetRef_:: target,
+      updatePolicy+: {
+        updateMode: mode,
+      },
+    },
+  },
 }

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -708,29 +708,28 @@
   },
 
   VerticalPodAutoscaler(name):: $._Object("autoscaling.k8s.io/v1beta2", "VerticalPodAutoscaler", name) {
+    local vpa = self,
+
+    target:: error "target required",
+
     spec: {
-      local spec = self,
-      targetRef_:: null,
-      targetRef: if spec.targetRef_ != null then {
-        apiVersion: spec.targetRef_.apiVersion,
-        kind: spec.targetRef_.kind,
-        name: spec.targetRef_.metadata.name,
-      } else {},
+      targetRef: $.CrossVersionObjectReference(vpa.target),
+
       updatePolicy: {
         updateMode: "Auto",
       },
-      assert self.targetRef != {} : "VerticalPodAutoscaler: must set a targetRef",
     },
   },
   // Helper function to ease VPA creation as e.g.:
   // foo_vpa:: kube.createVPAFor($.foo_deploy)
   createVPAFor(target, mode="Auto"):: $.VerticalPodAutoscaler(target.metadata.name) {
+    target:: target,
+
     metadata+: {
       namespace: target.metadata.namespace,
       labels+: target.metadata.labels,
     },
     spec+: {
-      targetRef_:: target,
       updatePolicy+: {
         updateMode: mode,
       },

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,7 +17,7 @@ PROJECT=kubelibsonnet
 
 tests: docker-compose-tests
 
-docker-compose-tests:
+docker-compose-tests: req-docker req-docker-compose
 	install -d $(TMP_RANCHER) $(TMP_RANCHER)/etc && touch $(TMP_RANCHER)/etc/k3s.yaml
 	USERID=$$(id -u) docker-compose -p $(PROJECT) up -d
 	rc=$$(timeout 60s docker wait $(DOCKER_E2E)) || rc=255 ;\
@@ -27,15 +27,14 @@ docker-compose-tests:
 	   exit $$rc
 	rm -rf ./$(TMP_RANCHER)
 
-test-srcs: unittests lint parse diff
-test-kube: validate
+local-tests: unittests lint parse diff
 
 # NB: unittest jsonnet files are also covered by parse and diff targets,
 #     called out here for convenience
-unittests:
+unittests: req-jsonnet
 	jsonnet $(UNITTEST_JSONNET)
 
-lint:
+lint: req-jsonnetfmt
 	@set -e; errs=0; \
         for f in $(ALL_JSONNET) $(LIB_JSONNET); do \
 	  if ! jsonnetfmt --test $(JSONNET_FMT) -- $$f; then \
@@ -49,11 +48,16 @@ lint:
 	  exit 1; \
 	fi
 
-parse: $(PHONY_PARSE)
+parse: req-jsonnet $(PHONY_PARSE)
 
 diff: diff-help $(PHONY_DIFF)
 
-validate:
+# Used to initialize docker'ized KubeAPI via k3s
+kube-init: req-kubectl req-kubecfg
+	kubectl version --short | grep k3s # void falsely initializing live clusters 
+	kubecfg update init-kube.jsonnet
+
+kube-validate: req-kubectl req-kubecfg
 	timeout 10 kubectl api-versions > /dev/null \
 	|| { echo "WARNING: no usable runtime kube context, skipping."; exit 0 ;} \
 	&& kubectl version --short && kubecfg version && kubecfg validate --ignore-unknown=false $(ALL_K8S_VALIDATE_JSONNET)
@@ -72,12 +76,15 @@ diff-help:
 	@echo "      $(MAKE) gen-golden diff"
 	@echo
 
-fix-lint:
+fix-lint: req-jsonnet
 	@set -e; \
 	for f in $(ALL_JSONNET) $(LIB_JSONNET); do \
 	  echo jsonnetfmt -i $(JSONNET_FMT) -- $$f; \
 	  jsonnetfmt -i $(JSONNET_FMT) -- $$f; \
 	done
+
+req-%:
+	@which $(*) >/dev/null && exit 0; echo "ERROR: '$(*)' is required in PATH"; exit 1
 
 gen-golden: $(PHONY_GOLDEN)
 

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -14,6 +14,10 @@ services:
     environment:
       - USER=nobody
       - HOME=/
+    tmpfs:
+      - /var/run
+      - /run
+      - /tmp
   e2e-test:
     build: .
     container_name: e2e-test
@@ -29,21 +33,4 @@ services:
       - HOME=/
     user: "${USERID}"
     command:
-      - bash
-      - -c
-      - |
-        echo "INFO: Starting tests: unit, lint ..."
-        make -C tests test-srcs
-        export KUBECONFIG=/tmp/kubeconfig
-        echo "INFO: Waiting for kube-api to be available ..."
-        until kubectl get nodes; do
-          sleep 1
-          # Found that k3s releases create k3s.yaml under diff paths,
-          # redirecting stderr just to avoid red-herrings errors
-          sed -e s/localhost/kube-api/ -e s/127.0.0.1/kube-api/ \
-            /tmp/rancher/k3s.yaml /tmp/rancher/etc/k3s.yaml \
-            > $$KUBECONFIG 2>/dev/null
-        done
-        echo "INFO: Starting tests: validate ..."
-        set -x
-        make -C tests test-kube
+      - tests/k3s-e2e-test.sh

--- a/tests/golden/init-kube.json
+++ b/tests/golden/init-kube.json
@@ -1,0 +1,32 @@
+{
+   "vpa_crd": {
+      "apiVersion": "apiextensions.k8s.io/v1beta1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+         "name": "verticalpodautoscalers.autoscaling.k8s.io"
+      },
+      "spec": {
+         "group": "autoscaling.k8s.io",
+         "names": {
+            "kind": "VerticalPodAutoscaler",
+            "listKind": "VerticalPodAutoscalerList",
+            "plural": "verticalpodautoscalers",
+            "singular": "verticalpodautoscaler"
+         },
+         "scope": "Namespaced",
+         "version": "v1beta1",
+         "versions": [
+            {
+               "name": "v1beta1",
+               "served": true,
+               "storage": false
+            },
+            {
+               "name": "v1beta2",
+               "served": true,
+               "storage": true
+            }
+         ]
+      }
+   }
+}

--- a/tests/golden/test-simple-validate.json
+++ b/tests/golden/test-simple-validate.json
@@ -157,6 +157,28 @@
          }
       },
       {
+         "apiVersion": "autoscaling.k8s.io/v1beta2",
+         "kind": "VerticalPodAutoscaler",
+         "metadata": {
+            "annotations": { },
+            "labels": {
+               "name": "foo-deploy"
+            },
+            "name": "foo-deploy",
+            "namespace": "foons"
+         },
+         "spec": {
+            "targetRef": {
+               "apiVersion": "apps/v1",
+               "kind": "Deployment",
+               "name": "foo-deploy"
+            },
+            "updatePolicy": {
+               "updateMode": "Auto"
+            }
+         }
+      },
+      {
          "apiVersion": "apps/v1",
          "kind": "DaemonSet",
          "metadata": {
@@ -724,6 +746,27 @@
                   }
                }
             ]
+         }
+      },
+      {
+         "apiVersion": "autoscaling.k8s.io/v1beta2",
+         "kind": "VerticalPodAutoscaler",
+         "metadata": {
+            "annotations": { },
+            "labels": {
+               "name": "foo-vpa"
+            },
+            "name": "foo-vpa"
+         },
+         "spec": {
+            "targetRef": {
+               "apiVersion": "apps/v1",
+               "kind": "Deployment",
+               "name": "foo-deploy"
+            },
+            "updatePolicy": {
+               "updateMode": "Auto"
+            }
          }
       }
    ],

--- a/tests/init-kube.jsonnet
+++ b/tests/init-kube.jsonnet
@@ -1,0 +1,16 @@
+local kube = import "../kube.libsonnet";
+
+local crds = {
+  // A simplified VPA CRD from https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
+  vpa_crd: kube.CustomResourceDefinition("autoscaling.k8s.io", "v1beta1", "VerticalPodAutoscaler") {
+    spec+: {
+      versions+: [
+        { name: "v1beta1", served: true, storage: false },
+        { name: "v1beta2", served: true, storage: true },
+      ],
+    },
+  },
+
+};
+
+crds

--- a/tests/k3s-e2e-test.sh
+++ b/tests/k3s-e2e-test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+echo "INFO: Starting tests: unit, lint ..."
+(set -x
+  make -C tests local-tests
+)
+export KUBECONFIG=/tmp/kubeconfig
+echo "INFO: Waiting for kube-api to be available ..."
+(set +e
+until kubectl get nodes; do
+  sleep 1
+  # Found that k3s releases create k3s.yaml under diff paths,
+  # redirecting stderr just to avoid red-herrings errors
+  sed -e s/localhost/kube-api/ -e s/127.0.0.1/kube-api/ \
+    /tmp/rancher/k3s.yaml /tmp/rancher/etc/k3s.yaml \
+    > ${KUBECONFIG:?} 2>/dev/null
+done
+)
+echo "INFO: initializing kube cluster: ..."
+(set -x
+  make -C tests kube-init
+)
+echo "INFO: Starting tests: test-kube ..."
+(set -x
+  make -C tests kube-validate
+)

--- a/tests/test-simple-validate.jsonnet
+++ b/tests/test-simple-validate.jsonnet
@@ -198,6 +198,18 @@ local stack = {
       },
     },
   },
+  // NB: these VPAs need the VPA CRD added to the cluster, for local k3s testing
+  // we add it via the `init-kube` Makefile target using `init-kube.jsonnet`
+  vpa: kube.VerticalPodAutoscaler($.name + "-vpa") {
+    spec+: {
+      targetRef: {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        name: "foo-deploy",
+      },
+    },
+  },
+  deploy_vpa: kube.createVPAFor($.deploy),
 };
 
 kube.List() {


### PR DESCRIPTION
* kube-libsonnet: add `VerticalPodAutoscaler` (aka VPA), and
  `createVPAFor` helper function
* tests/test-simple-validate.jsonnet: add VPA coverage
* tests/docker-compose.yaml: move embedded bash script to
  tests/k3s-e2e-test.sh
* Makefile: adjust e2e-tests, in particular as VPAs are CRs, need to
  initialize the dockerized k3s run with VPA CRD
  (tests/init-kube.jsonnet )