### PR TITLE
[jjo] Ingress: use networking.k8s.io/v1beta1 apiVersion

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -559,7 +559,7 @@
     },
   },
 
-  Ingress(name): $._Object("extensions/v1beta1", "Ingress", name) {
+  Ingress(name): $._Object("networking.k8s.io/v1beta1", "Ingress", name) {
     spec: {},
 
     local rel_paths = [

--- a/tests/.env
+++ b/tests/.env
@@ -1,9 +1,2 @@
-# As of Sept/2019, kube-api: k3s-release
-# - v1.13: v0.3.x
-# - v1.14: v0.4.x to v0.8.x
-# - v1.15: v0.9.x
-#
-# You can override with e.g.
-# K3S_VERSION=v0.9.1 make tests
-K3S_VERSION=v0.3.0
+K3S_VERSION=latest
 USERID=1000

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,8 +2,8 @@ FROM bitnami/minideb:buster
 MAINTAINER sre@bitnami.com
 
 ARG jsonnet_version=0.14.0
-ARG kubectl_version=v1.13.0
-ARG kubecfg_version=v0.12.0
+ARG kubectl_version=v1.17.0
+ARG kubecfg_version=v0.14.0
 
 RUN install_packages jq make curl ca-certificates
 RUN adduser --home /home/user --disabled-password --gecos User user

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,16 @@
+# K3S_<KUBE_MAJOR_RELEASE> as a "mapping" from KUBE_MAJOR_RELEASE to k3s tag
+K3S_V1_13=v0.3.0 # no-more to support v1.18 previous Ingress apiVersion deprecation
+K3S_V1_14=v0.8.0
+K3S_V1_15=v0.9.0
+K3S_V1_16=v1.0.1
+K3S_V1_17=v1.17.2-k3s1
+#
+# Since https://github.com/bitnami-labs/kube-libsonnet/issues/32 we support
+# kubernetes v1.14+ (Ingress apiVersion deprecated in v1.18, available since v1.14).
+#
+# Kubernetes releases we cover with e2e testing:
+E2E_K3S_VERSIONS=$(K3S_V1_14) $(K3S_V1_15) $(K3S_V1_16) $(K3S_V1_17)
+
 SHELL=/bin/bash
 JSONNET_FMT=--indent 2 --string-style d --comment-style s --no-pad-arrays --pad-objects --pretty-field-names
 
@@ -15,17 +28,21 @@ DOCKER_E2E=e2e-test
 TMP_RANCHER=./tmp-rancher
 PROJECT=kubelibsonnet
 
-tests: docker-compose-tests
+tests: $(patsubst %,e2e-tests-%,$(E2E_K3S_VERSIONS))
+	@echo "SUCCESS: verified Kubernetes versions:"
+	@cat $(TMP_RANCHER)/report.txt
+	@rm -rf ./$(TMP_RANCHER)
 
-docker-compose-tests: req-docker req-docker-compose
-	install -d $(TMP_RANCHER) $(TMP_RANCHER)/etc && touch $(TMP_RANCHER)/etc/k3s.yaml
-	USERID=$$(id -u) docker-compose -p $(PROJECT) up -d
+e2e-tests-%: req-docker req-docker-compose
+	install -d $(TMP_RANCHER)/root/etc && touch $(TMP_RANCHER)/root/etc/k3s.yaml
+	env USERID=$$(id -u) K3S_VERSION=$(*) docker-compose -p $(PROJECT) up -d
 	rc=$$(timeout 60s docker wait $(DOCKER_E2E)) || rc=255 ;\
 	   test $$rc -ne 0 && docker logs k3s-api;\
-	   docker logs $(DOCKER_E2E);\
-	   docker-compose -p $(PROJECT) down;\
+	   docker logs $(DOCKER_E2E); \
 	   exit $$rc
-	rm -rf ./$(TMP_RANCHER)
+	docker logs $(DOCKER_E2E)| egrep '^Server.Version.+' | sort -u >> $(TMP_RANCHER)/report.txt
+	docker-compose -p $(PROJECT) down
+	rm -rf ./$(TMP_RANCHER)/root
 
 local-tests: unittests lint parse diff
 
@@ -54,7 +71,7 @@ diff: diff-help $(PHONY_DIFF)
 
 # Used to initialize docker'ized KubeAPI via k3s
 kube-init: req-kubectl req-kubecfg
-	kubectl version --short | grep k3s # void falsely initializing live clusters 
+	kubectl version --short | grep k3s # void falsely initializing live clusters
 	kubecfg update init-kube.jsonnet
 
 kube-validate: req-kubectl req-kubecfg

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -5,9 +5,9 @@ services:
     command: server --disable-agent
     container_name: k3s-api
     volumes:
-      - ./tmp-rancher:/.kube
-      - ./tmp-rancher:/.rancher
-      - ./tmp-rancher/etc:/etc/rancher/k3s
+      - ./tmp-rancher/root:/.kube
+      - ./tmp-rancher/root:/.rancher
+      - ./tmp-rancher/root/etc:/etc/rancher/k3s
     expose:
       - 6443
     user: "${USERID}"
@@ -26,7 +26,7 @@ services:
     depends_on:
       - kube-api
     volumes:
-      - ./tmp-rancher:/tmp/rancher
+      - ./tmp-rancher/root:/tmp/rancher
       - ..:/work
     working_dir: /work
     environment:

--- a/tests/golden/test-simple-validate.json
+++ b/tests/golden/test-simple-validate.json
@@ -263,7 +263,7 @@
          }
       },
       {
-         "apiVersion": "extensions/v1beta1",
+         "apiVersion": "networking.k8s.io/v1beta1",
          "kind": "Ingress",
          "metadata": {
             "annotations": {


### PR DESCRIPTION
Fixes #32.

* Ingress: use networking.k8s.io/v1beta1 apiVersion: deprecated on
  v1.18+, available since v1.14

* rework e2e testing to cover several releases, see

  $ grep E2E_K3S_VERSIONS= tests/Makefile
  E2E_K3S_VERSIONS=$(K3S_V1_14) $(K3S_V1_15) $(K3S_V1_16) $(K3S_V1_17)

* e2e testing now shows tested releases:

  SUCCESS: verified Kubernetes versions:
  Server Version: v1.14.5-k3s.1
  Server Version: v1.15.4-k3s.1
  Server Version: v1.16.3-k3s.2
  Server Version: v1.17.2+k3s1