### PR TITLE
Add ManagedCertificates and Backend Config objects

### DIFF
--- a/kube-platforms.libsonnet
+++ b/kube-platforms.libsonnet
@@ -1,0 +1,21 @@
+// Extend kube.libsonnet for platform specific CRDs, drop-in usage as:
+//
+// local kube = import "kube-platforms.jsonnet";
+// {
+//    my_deploy: kube.Deployment(...) { ... }
+//    my_gke_cert: kube.gke.ManagedCertificate(...) { ... }
+// }
+(import "kube.libsonnet") {
+  gke:: {
+    ManagedCertificate(name): $._Object("networking.gke.io/v1beta1", "ManagedCertificate", name) {
+      spec: {
+        domains: error "spec.domains array is required",
+      },
+      assert std.length(self.spec.domains) > 0 : "ManagedCertificate '%s' spec.domains array must not be empty" % self.metadata.name,
+    },
+
+    BackendConfig(name): $._Object("cloud.google.com/v1beta1", "BackendConfig", name) {
+      spec: {},
+    },
+  },
+}

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -577,13 +577,13 @@
     assert std.length(rel_paths) == 0 : "paths must be absolute: " + rel_paths,
   },
 
-  ManagedCertificates(name, domains): $._Object('networking.gke.io/v1beta1', 'ManagedCertificate', name) {
+  ManagedCertificates(name, domains): $._Object("networking.gke.io/v1beta1", "ManagedCertificate", name) {
     spec: {
       domains: domains,
     },
   },
 
-  BackendConfig(name): $._Object('cloud.google.com/v1beta1', 'BackendConfig', name) {
+  BackendConfig(name): $._Object("cloud.google.com/v1beta1", "BackendConfig", name) {
     spec: {},
   },
 

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -577,19 +577,6 @@
     assert std.length(rel_paths) == 0 : "paths must be absolute: " + rel_paths,
   },
 
-  gke:: {
-    ManagedCertificate(name): $._Object("networking.gke.io/v1beta1", "ManagedCertificate", name) {
-      spec: {
-        domains: error "spec.domains array is required",
-      },
-      assert std.length(self.spec.domains) > 0 : "ManagedCertificate '%s' spec.domains array must not be empty" % self.metadata.name,
-    },
-
-    BackendConfig(name): $._Object("cloud.google.com/v1beta1", "BackendConfig", name) {
-      spec: {},
-    },
-  },
-
   ThirdPartyResource(name): $._Object("extensions/v1beta1", "ThirdPartyResource", name) {
     versions_:: [],
     versions: [{ name: n } for n in self.versions_],

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -577,6 +577,16 @@
     assert std.length(rel_paths) == 0 : "paths must be absolute: " + rel_paths,
   },
 
+  ManagedCertificates(name): $._Object('networking.gke.io/v1beta1', 'ManagedCertificate', name, domains) {
+    spec: {
+      domains: domains,
+    },
+  },
+
+  BackendConfig(name): $._Object('cloud.google.com/v1beta1', 'BackendConfig', name) {
+    spec: {},
+  },
+
   ThirdPartyResource(name): $._Object("extensions/v1beta1", "ThirdPartyResource", name) {
     versions_:: [],
     versions: [{ name: n } for n in self.versions_],

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -577,7 +577,7 @@
     assert std.length(rel_paths) == 0 : "paths must be absolute: " + rel_paths,
   },
 
-  ManagedCertificates(name): $._Object('networking.gke.io/v1beta1', 'ManagedCertificate', name, domains) {
+  ManagedCertificates(name, domains): $._Object('networking.gke.io/v1beta1', 'ManagedCertificate', name) {
     spec: {
       domains: domains,
     },

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -577,14 +577,17 @@
     assert std.length(rel_paths) == 0 : "paths must be absolute: " + rel_paths,
   },
 
-  ManagedCertificates(name, domains): $._Object("networking.gke.io/v1beta1", "ManagedCertificate", name) {
-    spec: {
-      domains: domains,
+  gke:: {
+    ManagedCertificate(name): $._Object("networking.gke.io/v1beta1", "ManagedCertificate", name) {
+      spec: {
+        domains: error "spec.domains array is required",
+      },
+      assert std.length(self.spec.domains) > 0 : "ManagedCertificate '%s' spec.domains array must not be empty" % self.metadata.name,
     },
-  },
 
-  BackendConfig(name): $._Object("cloud.google.com/v1beta1", "BackendConfig", name) {
-    spec: {},
+    BackendConfig(name): $._Object("cloud.google.com/v1beta1", "BackendConfig", name) {
+      spec: {},
+    },
   },
 
   ThirdPartyResource(name): $._Object("extensions/v1beta1", "ThirdPartyResource", name) {

--- a/tests/golden/test-gke-ManagedCertificate.pass.json
+++ b/tests/golden/test-gke-ManagedCertificate.pass.json
@@ -1,0 +1,22 @@
+{
+   "apiVersion": "v1",
+   "items": [
+      {
+         "apiVersion": "networking.gke.io/v1beta1",
+         "kind": "ManagedCertificate",
+         "metadata": {
+            "annotations": { },
+            "labels": {
+               "name": "foo"
+            },
+            "name": "foo"
+         },
+         "spec": {
+            "domains": [
+               "foo.example.com"
+            ]
+         }
+      }
+   ],
+   "kind": "List"
+}

--- a/tests/test-gke-ManagedCertificate.fail.jsonnet
+++ b/tests/test-gke-ManagedCertificate.fail.jsonnet
@@ -1,0 +1,12 @@
+local kube = import "../kube-platforms.libsonnet";
+local stack = {
+  foocert: kube.gke.ManagedCertificate("foo") {
+    spec+: {
+      domains: [],
+    },
+  },
+};
+
+kube.List() {
+  items_+: stack,
+}

--- a/tests/test-gke-ManagedCertificate.pass.jsonnet
+++ b/tests/test-gke-ManagedCertificate.pass.jsonnet
@@ -1,0 +1,12 @@
+local kube = import "../kube-platforms.libsonnet";
+local stack = {
+  foocert: kube.gke.ManagedCertificate("foo") {
+    spec+: {
+      domains: ["foo.example.com"],
+    },
+  },
+};
+
+kube.List() {
+  items_+: stack,
+}


### PR DESCRIPTION
Adds missing objects `ManagedCertificate` and `BackendConfig`, scoped to `gke::` namespace

## usage:
### ManagedCertificate
```
 my_cert: kube.gke.ManagedCertificate("my-cert") {
    spec+: {
       domains: ["foo.example.com"],
    },
  }
```

### BackendConfig
```
 my_cert: kube.gke.BackendConfig("config") {
    spec+: {
      cdn: {
        enabled: true
      },
    },
  }
```