### PR TITLE
ConfigMap: disable string validation

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -340,18 +340,7 @@
     configMap: { name: configmap.metadata.name },
   },
 
-  ConfigMap(name): $._Object("v1", "ConfigMap", name) {
-    data: {},
-
-    // I keep thinking data values can be any JSON type.  This check
-    // will remind me that they must be strings :(
-    local nonstrings = [
-      k
-      for k in std.objectFields(self.data)
-      if std.type(self.data[k]) != "string"
-    ],
-    assert std.length(nonstrings) == 0 : "data contains non-string values: %s" % [nonstrings],
-  },
+  ConfigMap(name): $._Object("v1", "ConfigMap", name),
 
   // subtype of EnvVarSource
   ConfigMapRef(configmap, key): {


### PR DESCRIPTION
Hello,

Thank your for this great library, this is extremely useful!

I having problems with slow builds on a project of mine.
After some investigation, it appears that the "string" validation in ConfigMap() was causing this.
I am jsonnet-newbie, and I thus have no idea how/if this can be optimized.

Do you have any idea what can be done to improve this? WDYT?

On my project, compilation time is:
- 45 seconds with string validation
- 12 seconds without string validation

(Note that I am sharing this PR just to illustrate the problematic code, I am not suggesting the right solution is to remove the check completely).

Signed-off-by: Gregory Vander Schueren <gregory.vanderschueren@tessares.net>