### PR TITLE
Fix typo in HashedSecret negative test

### DIFF
--- a/tests/unittests.pass.jsonnet
+++ b/tests/unittests.pass.jsonnet
@@ -108,7 +108,7 @@ std.assertEqual(
       data+: { foo: std.base64("bar") },
     }.metadata.name
     ==
-    (utils.HashedConfigMap("hashed-secret")) {
+    (utils.HashedSecret("hashed-secret")) {
       data+: { foo: std.base64("baz") },
     }.metadata.name
   ),


### PR DESCRIPTION
Fix typo in HashedSecret negative test so that the test fails for the right reason :P