### PR TITLE
[jjo] feat: improve cert-manager support

### DIFF
--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -64,7 +64,7 @@ local perCloudSvcSpec(cloud) = (
       annotations+: {
         // Add ingress class iff specified
         [if class != null then "kubernetes.io/ingress.class" else null]: class,
-      }
+      },
     },
     spec+: {
       tls: [
@@ -148,7 +148,7 @@ local perCloudSvcSpec(cloud) = (
     //   my_cert: kube.CertManager.InCluster.Certificate("my-tls-cert", "my-namespace")
     // to get a Kubernetes TLS secret named "my-tls-cert" in "my-namespace"
     Certificate(name):: kube._Object("cert-manager.io/v1alpha2", "Certificate", name) {
-      assert std.objectHas(self.metadata, "namespace"): "Certificate('%s') must set metadata.namespace" % self.metadata.name,
+      assert std.objectHas(self.metadata, "namespace") : "Certificate('%s') must set metadata.namespace" % self.metadata.name,
     },
 
     InCluster:: {

--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -144,9 +144,7 @@ local perCloudSvcSpec(cloud) = (
     // CertManager ClusterIssuer object
     ClusterIssuer(name):: kube._Object("cert-manager.io/v1alpha2", "ClusterIssuer", name),
 
-    // Use as:
-    //   my_cert: kube.CertManager.InCluster.Certificate("my-tls-cert", "my-namespace")
-    // to get a Kubernetes TLS secret named "my-tls-cert" in "my-namespace"
+    // CertManager Certificate object
     Certificate(name):: kube._Object("cert-manager.io/v1alpha2", "Certificate", name) {
       assert std.objectHas(self.metadata, "namespace") : "Certificate('%s') must set metadata.namespace" % self.metadata.name,
     },
@@ -160,6 +158,9 @@ local perCloudSvcSpec(cloud) = (
           selfSigned: {},
         },
       },
+      // Use as:
+      //   my_cert: kube.CertManager.InCluster.Certificate("my-tls-cert", "my-namespace")
+      // to get a Kubernetes TLS secret named "my-tls-cert" in "my-namespace"
       Certificate(name, namespace):: $.CertManager.Certificate(name) {
         metadata+: { namespace: namespace },
         spec+: {

--- a/tests/golden/test-simple-validate.pass.json
+++ b/tests/golden/test-simple-validate.pass.json
@@ -333,10 +333,7 @@
          "kind": "Ingress",
          "metadata": {
             "annotations": {
-               "cert-manager.io/cluster-issuer": "letsencrypt-prod-dns",
-               "certmanager.k8s.io/acme-challenge-type": "dns01",
-               "certmanager.k8s.io/acme-dns01-provider": "default",
-               "certmanager.k8s.io/cluster-issuer": "letsencrypt-prod-dns"
+               "cert-manager.io/cluster-issuer": "letsencrypt-prod-dns"
             },
             "labels": {
                "name": "foo-ingress"
@@ -821,6 +818,35 @@
                      }
                   }
                }
+            ]
+         }
+      },
+      {
+         "apiVersion": "cert-manager.io/v1alpha2",
+         "kind": "Certificate",
+         "metadata": {
+            "annotations": { },
+            "labels": {
+               "name": "foo-cert"
+            },
+            "name": "foo-cert",
+            "namespace": "foons"
+         },
+         "spec": {
+            "commonName": "foo-cert",
+            "dnsNames": [
+               "foo-cert",
+               "foo-cert.foons",
+               "foo-cert.foons.svc"
+            ],
+            "issuerRef": {
+               "kind": "ClusterIssuer",
+               "name": "in-cluster-issuer"
+            },
+            "secretName": "foo-cert",
+            "usages": [
+               "digital signature",
+               "key encipherment"
             ]
          }
       },

--- a/tests/init-kube.jsonnet
+++ b/tests/init-kube.jsonnet
@@ -10,7 +10,9 @@ local crds = {
       ],
     },
   },
-
+  // Simplified cert-manager CRD from https://github.com/jetstack/cert-manager/blob/master/deploy/crds/crd-certificates.yaml,
+  // enough to test bitnami.CertManager object(s)
+  cm_certificate_crd: kube.CustomResourceDefinition("cert-manager.io", "v1alpha2", "Certificate"),
 };
 
 crds

--- a/tests/test-simple-validate.pass.jsonnet
+++ b/tests/test-simple-validate.pass.jsonnet
@@ -221,6 +221,7 @@ local stack = {
     },
   },
   deploy_vpa: kube.createVPAFor($.deploy),
+  tls_cert: bitnami.CertManager.InCluster.Certificate("foo-cert", $.namespace),
 };
 
 kube.List() {


### PR DESCRIPTION
Improve cert-manager support in bitnami.libsonnet:
* add CertManager section (field) with all needed bits
* add CertManager.InCluster.Certificate() function to ease
  issuing in-cluster certs
* move many Ingress related bits under CertManager field,
  remove old cruft