### PR TITLE
Feat: Increase tests coverage - k3s-1.19

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,13 +7,15 @@ K3S_V1_16=v1.0.1
 # Since v1.17 k3s image tags follow Kubernetes releases numbering
 K3S_V1_17=v1.17.2-k3s1
 K3S_V1_18=v1.18.2-k3s1
+K3S_V1_18=v1.18.2-k3s1
+K3S_V1_19=v1.19.2-k3s1
 #
 # Since https://github.com/bitnami-labs/kube-libsonnet/issues/32 we only support
 # kubernetes v1.14+ (Ingress apiVersion deprecated in v1.18, available since v1.14).
 #
 # Kubernetes releases we cover with e2e testing,
 # we'll run `docker-compose` for each to below rancher/k3s versions (tags)
-E2E_K3S_VERSIONS=$(K3S_V1_14) $(K3S_V1_15) $(K3S_V1_16) $(K3S_V1_17) $(K3S_V1_18)
+E2E_K3S_VERSIONS=$(K3S_V1_14) $(K3S_V1_15) $(K3S_V1_16) $(K3S_V1_17) $(K3S_V1_18) $(K3S_V1_19)
 
 SHELL=/bin/bash
 # Rather arbitrary Bitnami style choice


### PR DESCRIPTION
Signed-off-by: David Barranco <dbarranco@vmware.com>

```
docker-compose -p kubelibsonnet down
Stopping k3s-api ... done
Removing e2e-test ... done
Removing k3s-api  ... done
Removing network kubelibsonnet_default
rm -rf ././tmp-rancher/root
SUCCESS: verified Kubernetes versions:
Server Version: v1.14.5-k3s.1
Server Version: v1.15.4-k3s.1
Server Version: v1.16.3-k3s.2
Server Version: v1.17.2+k3s1
Server Version: v1.18.2+k3s1
Server Version: v1.19.2+k3s1
```