### PR TITLE
add imagePullSecrets "dockerhub-dockerconfig" to SAs

### DIFF
--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -118,6 +118,11 @@ local perCloudSvcSpec(cloud) = (
       ],
     },
   },
+
+  ServiceAccount(name): kube.ServiceAccount(name) {
+    imagePullSecrets: { name: "dockerhub-dockerconfig" },
+  },
+
   CertManager:: {
     // Deployed cluster issuers' names:
     cluster_issuers:: {

--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -120,7 +120,7 @@ local perCloudSvcSpec(cloud) = (
   },
   // use a Docker config to pull from DockerHub
   ServiceAccount(name): kube.ServiceAccount(name) {
-    imagePullSecrets: { name: "dockerhub-dockerconfig" },
+    imagePullSecrets: [{ name: "dockerhub-dockerconfig" }],
   },
 
   CertManager:: {

--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -118,7 +118,11 @@ local perCloudSvcSpec(cloud) = (
       ],
     },
   },
-
+  // The secret will be only available on those clusters who make use of
+  // ClusterSecrets, which replicates the source secret to desired namespaces in
+  // the cluster. It's the case for g.dev
+  // AWS clusters are KOPS managed clusters doesn't need any imagePullSecret definition since
+  // use a Docker config in the nodes, so the pull is authenticated out of K8s
   ServiceAccount(name): kube.ServiceAccount(name) {
     imagePullSecrets: { name: "dockerhub-dockerconfig" },
   },

--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -118,11 +118,7 @@ local perCloudSvcSpec(cloud) = (
       ],
     },
   },
-  // The secret will be only available on those clusters who make use of
-  // ClusterSecrets, which replicates the source secret to desired namespaces in
-  // the cluster. It's the case for g.dev
-  // AWS clusters are KOPS managed clusters doesn't need any imagePullSecret definition since
-  // use a Docker config in the nodes, so the pull is authenticated out of K8s
+  // use a Docker config to pull from DockerHub
   ServiceAccount(name): kube.ServiceAccount(name) {
     imagePullSecrets: { name: "dockerhub-dockerconfig" },
   },


### PR DESCRIPTION
As part of the authenticated pull from DockerHub, we'll be setting the  "dockerhub-dockerconfig" imagePullSecret as default for 'bitnami.libsonnet' library.

Any project using this library can assign this imagePullSecret to a ServiceAccount by using 

```nginx_ingress_service_account: bitnami.ServiceAccount("nginx-ingress") ```

This snippet will be added to the SA:

```
   "imagePullSecrets": {
      "name": "dockerhub-dockerconfig"
   },
```

The secret will be only available on those clusters who make use of ClusterSecrets, which replicates the source secret to desired namespaces in the cluster.

KOPS managed clusters doesn't need any imagePullSecret definition since use a Docker config in the nodes, so the pull is authenticated out of K8s 
