### PR TITLE
add container_index for service object

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -157,7 +157,8 @@
     local service = self,
 
     target_pod:: error "service target_pod required",
-    port:: self.target_pod.spec.containers[0].ports[0].containerPort,
+    container_index:: 0,
+    port:: self.target_pod.spec.containers[service.container_index].ports[0].containerPort,
 
     // Helpers that format host:port in various ways
     host:: "%s.%s.svc" % [self.metadata.name, self.metadata.namespace],
@@ -178,8 +179,8 @@
       ports: [
         {
           port: service.port,
-          name: service.target_pod.spec.containers[0].ports[0].name,
-          targetPort: service.target_pod.spec.containers[0].ports[0].containerPort,
+          name: service.target_pod.spec.containers[service.container_index].ports[0].name,
+          targetPort: service.target_pod.spec.containers[service.container_index].ports[0].containerPort,
         },
       ],
       type: "ClusterIP",

--- a/tests/golden/test-Service-container_index.pass.json
+++ b/tests/golden/test-Service-container_index.pass.json
@@ -1,0 +1,169 @@
+{
+   "deploy": {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+         "annotations": { },
+         "labels": {
+            "name": "test-Service-pass-deploy"
+         },
+         "name": "test-Service-pass-deploy"
+      },
+      "spec": {
+         "minReadySeconds": 30,
+         "replicas": 1,
+         "revisionHistoryLimit": 10,
+         "selector": {
+            "matchLabels": {
+               "name": "test-Service-pass-deploy"
+            }
+         },
+         "strategy": {
+            "rollingUpdate": {
+               "maxSurge": "25%",
+               "maxUnavailable": "25%"
+            },
+            "type": "RollingUpdate"
+         },
+         "template": {
+            "metadata": {
+               "annotations": { },
+               "labels": {
+                  "name": "test-Service-pass-deploy"
+               }
+            },
+            "spec": {
+               "containers": [
+                  {
+                     "args": [ ],
+                     "env": [ ],
+                     "image": "nginx:1.12",
+                     "imagePullPolicy": "IfNotPresent",
+                     "name": "test-Service-pass-default",
+                     "ports": [
+                        {
+                           "containerPort": 80,
+                           "name": "http"
+                        },
+                        {
+                           "containerPort": 9099,
+                           "name": "metrics"
+                        }
+                     ],
+                     "stdin": false,
+                     "tty": false,
+                     "volumeMounts": [ ]
+                  },
+                  {
+                     "args": [ ],
+                     "env": [ ],
+                     "image": "nginx:1.12",
+                     "imagePullPolicy": "IfNotPresent",
+                     "name": "test-Service-pass-sidecar",
+                     "ports": [
+                        {
+                           "containerPort": 80,
+                           "name": "http-sidecar"
+                        },
+                        {
+                           "containerPort": 9099,
+                           "name": "metrics"
+                        }
+                     ],
+                     "stdin": false,
+                     "tty": false,
+                     "volumeMounts": [ ]
+                  }
+               ],
+               "imagePullSecrets": [ ],
+               "initContainers": [ ],
+               "terminationGracePeriodSeconds": 30,
+               "volumes": [ ]
+            }
+         }
+      }
+   },
+   "pod": {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+         "annotations": { },
+         "labels": {
+            "name": "test-Service-pass-pod"
+         },
+         "name": "test-Service-pass-pod"
+      },
+      "spec": {
+         "containers": [
+            {
+               "args": [ ],
+               "env": [ ],
+               "image": "nginx:1.12",
+               "imagePullPolicy": "IfNotPresent",
+               "name": "test-Service-pass-default",
+               "ports": [
+                  {
+                     "containerPort": 80,
+                     "name": "http"
+                  },
+                  {
+                     "containerPort": 9099,
+                     "name": "metrics"
+                  }
+               ],
+               "stdin": false,
+               "tty": false,
+               "volumeMounts": [ ]
+            },
+            {
+               "args": [ ],
+               "env": [ ],
+               "image": "nginx:1.12",
+               "imagePullPolicy": "IfNotPresent",
+               "name": "test-Service-pass-sidecar",
+               "ports": [
+                  {
+                     "containerPort": 80,
+                     "name": "http-sidecar"
+                  },
+                  {
+                     "containerPort": 9099,
+                     "name": "metrics"
+                  }
+               ],
+               "stdin": false,
+               "tty": false,
+               "volumeMounts": [ ]
+            }
+         ],
+         "imagePullSecrets": [ ],
+         "initContainers": [ ],
+         "terminationGracePeriodSeconds": 30,
+         "volumes": [ ]
+      }
+   },
+   "service": {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+         "annotations": { },
+         "labels": {
+            "name": "test-Service-pass-svc"
+         },
+         "name": "test-Service-pass-svc"
+      },
+      "spec": {
+         "ports": [
+            {
+               "name": "http-sidecar",
+               "port": 80,
+               "targetPort": 80
+            }
+         ],
+         "selector": {
+            "name": "test-Service-pass-deploy"
+         },
+         "type": "ClusterIP"
+      }
+   }
+}

--- a/tests/test-Service-container_index.fail.jsonnet
+++ b/tests/test-Service-container_index.fail.jsonnet
@@ -1,0 +1,42 @@
+local bitnami = import "../bitnami.libsonnet";
+local kube = import "../kube.libsonnet";
+
+local stack = {
+  name:: "test-Service-pass",
+  pod: kube.Pod($.name + "-pod") {
+    spec+: {
+      containers_+: {
+        default: kube.Container($.name + "-default") {
+          image: "nginx:1.12",
+          ports_+: {
+            http: { containerPort: 80 },
+            metrics: { containerPort: 9099 },
+          },
+        },
+        sidecar: kube.Container($.name + "-sidecar") {
+          image: "nginx:1.12",
+          ports_+: {
+            sidecar: { containerPort: 80 },
+            metrics: { containerPort: 9099 },
+          },
+        },
+      },
+    },
+  },
+  deploy: kube.Deployment($.name + "-deploy") {
+    local this = self,
+    spec+: {
+      template+: {
+        spec+: $.pod.spec,
+      },
+    },
+  },
+  service: kube.Service($.name + "-svc") {
+    local this = self,
+    target_pod: $.deploy.spec.template,
+    // Force fail by selecting an index out of range.
+    container_index: 3,
+  },
+};
+
+stack

--- a/tests/test-Service-container_index.pass.jsonnet
+++ b/tests/test-Service-container_index.pass.jsonnet
@@ -1,0 +1,44 @@
+local bitnami = import "../bitnami.libsonnet";
+local kube = import "../kube.libsonnet";
+
+local stack = {
+  name:: "test-Service-pass",
+  pod: kube.Pod($.name + "-pod") {
+    spec+: {
+      containers_+: {
+        default: kube.Container($.name + "-default") {
+          image: "nginx:1.12",
+          ports_+: {
+            http: { containerPort: 80 },
+            metrics: { containerPort: 9099 },
+          },
+        },
+        sidecar: kube.Container($.name + "-sidecar") {
+          image: "nginx:1.12",
+          ports_+: {
+            http_sidecar: { containerPort: 80 },
+            metrics: { containerPort: 9099 },
+          },
+        },
+      },
+    },
+  },
+  deploy: kube.Deployment($.name + "-deploy") {
+    local this = self,
+    spec+: {
+      template+: {
+        spec+: $.pod.spec,
+      },
+    },
+  },
+  service: kube.Service($.name + "-svc") {
+    local this = self,
+    target_pod: $.deploy.spec.template,
+    container_index: 1,
+  },
+};
+
+stack {
+  // Assert we got the 2nd containers port named "http" for service
+  assert (stack.service.spec.ports[0].name == "http-sidecar") : "Expected service port http-sidecar.",
+}


### PR DESCRIPTION
The current helper only works for the first container, having this index hidden variable allows us to expose services from a second sidecar type container in the same pod.