### PR TITLE
Allow specifying Ingress rules with http.paths with no path.

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -585,7 +585,7 @@
       p.path
       for r in self.spec.rules
       for p in r.http.paths
-      if !std.startsWith(p.path, "/")
+      if std.objectHas(p, "path") && !std.startsWith(p.path, "/")
     ],
     assert (!$._assert) || std.length(rel_paths) == 0 : "paths must be absolute: " + rel_paths,
   },

--- a/tests/golden/test-simple-validate.pass.json
+++ b/tests/golden/test-simple-validate.pass.json
@@ -523,6 +523,48 @@
          }
       },
       {
+         "apiVersion": "networking.k8s.io/v1beta1",
+         "kind": "Ingress",
+         "metadata": {
+            "annotations": { },
+            "labels": {
+               "name": "foo-pathless-ingress"
+            },
+            "name": "foo-pathless-ingress",
+            "namespace": "foons"
+         },
+         "spec": {
+            "rules": [
+               {
+                  "host": "a.example.com",
+                  "http": {
+                     "paths": [
+                        {
+                           "backend": {
+                              "serviceName": "service-a",
+                              "servicePort": "web"
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  "host": "b.example.com",
+                  "http": {
+                     "paths": [
+                        {
+                           "backend": {
+                              "serviceName": "service-2",
+                              "servicePort": "web"
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
          "apiVersion": "v1",
          "kind": "Pod",
          "metadata": {

--- a/tests/test-simple-validate.pass.jsonnet
+++ b/tests/test-simple-validate.pass.jsonnet
@@ -60,6 +60,37 @@ local stack = {
     target_svc: $.service,
   },
 
+  // An ingress with multiple hosts but none of the hosts specifies a path (#54).
+  pathlessIngress: kube.Ingress($.name + "-pathless-ingress") {
+    metadata+: { namespace: $.namespace },
+    spec+: {
+      rules+: [
+        {
+          host: "a.example.com",
+          http: {
+            paths: [{
+              backend: {
+                serviceName: "service-a",
+                servicePort: "web",
+              },
+            }],
+          },
+        },
+        {
+          host: "b.example.com",
+          http: {
+            paths: [{
+              backend: {
+                serviceName: "service-2",
+                servicePort: "web",
+              },
+            }],
+          },
+        },
+      ],
+    },
+  },
+
   // NB: just a simple example pod
   pod: kube.Pod($.name + "-pod") {
     metadata+: { namespace: $.namespace },


### PR DESCRIPTION
These can be rules that map different hostnames to backends, where each
backend handles all paths, so has no `path` field. For example:

```
spec:
  rules:
  - host: a.example.com
    http:
      paths:
      - backend:
          serviceName: service-a
          servicePort: web
  - host: b.example.com
    http:
      paths:
      - backend:
          serviceName: service-b
          servicePort: web
```

Currently this fails with:

```
RUNTIME ERROR: Field does not exist: path
	kube-libsonnet/kube.libsonnet:588:26-32	thunk from <object <anonymous>>
```