### PR TITLE
Don't crash when the ingress rule has no `path`.

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -585,7 +585,7 @@
       p.path
       for r in self.spec.rules
       for p in r.http.paths
-      if !std.startsWith(p.path, "/")
+      if std.objectHas(p, "path") && !std.startsWith(p.path, "/")
     ],
     assert (!$._assert) || std.length(rel_paths) == 0 : "paths must be absolute: " + rel_paths,
   },


### PR DESCRIPTION
The `path` attribute is optional for k8s ingresses (it defaults to `/`), however the library here crashes if it's not specified.

The relative path check is only useful if path is specified, so add a check to see if it's there before attempting to read it.