### PR TITLE
[jjo] support Kubernetes v1.22+ apiVersions deprecations

### DIFF
--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -52,7 +52,13 @@ local perCloudSvcSpec(cloud) = (
     host:: error "host required",
     target_svc:: error "target_svc required",
     // Default to single-service - override if you want something else.
-    paths:: [{ path: "/", backend: ing.target_svc.name_port }],
+    paths:: [
+      {
+        path: "/",
+        backend: ing.target_svc.name_port,
+        pathType: "ImplementationSpecific",
+      },
+    ],
     secretName:: "%s-cert" % [ing.metadata.name],
 
     // cert_provider can either be:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,7 @@ K3S_V1_21=v1.21.1-k3s1
 #
 # Kubernetes releases we cover with e2e testing,
 # we'll run `docker-compose` for each to below rancher/k3s versions (tags)
-E2E_K3S_VERSIONS=$(K3S_V1_14) $(K3S_V1_15) $(K3S_V1_16) $(K3S_V1_17) $(K3S_V1_18) $(K3S_V1_19) $(K3S_V1_20) $(K3S_V1_21)
+E2E_K3S_VERSIONS=$(K3S_V1_19) $(K3S_V1_20) $(K3S_V1_21)
 
 SHELL=/bin/bash
 # Rather arbitrary Bitnami style choice

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,17 +5,18 @@ K3S_V1_14=v0.8.0
 K3S_V1_15=v0.9.0
 K3S_V1_16=v1.0.1
 # Since v1.17 k3s image tags follow Kubernetes releases numbering
-K3S_V1_17=v1.17.2-k3s1
-K3S_V1_18=v1.18.2-k3s1
-K3S_V1_18=v1.18.2-k3s1
-K3S_V1_19=v1.19.2-k3s1
+K3S_V1_17=v1.17.17-k3s1
+K3S_V1_18=v1.18.19-k3s1
+K3S_V1_19=v1.19.11-k3s1
+K3S_V1_20=v1.20.7-k3s1
+K3S_V1_21=v1.21.1-k3s1
 #
 # Since https://github.com/bitnami-labs/kube-libsonnet/issues/32 we only support
 # kubernetes v1.14+ (Ingress apiVersion deprecated in v1.18, available since v1.14).
 #
 # Kubernetes releases we cover with e2e testing,
 # we'll run `docker-compose` for each to below rancher/k3s versions (tags)
-E2E_K3S_VERSIONS=$(K3S_V1_14) $(K3S_V1_15) $(K3S_V1_16) $(K3S_V1_17) $(K3S_V1_18) $(K3S_V1_19)
+E2E_K3S_VERSIONS=$(K3S_V1_14) $(K3S_V1_15) $(K3S_V1_16) $(K3S_V1_17) $(K3S_V1_18) $(K3S_V1_19) $(K3S_V1_20) $(K3S_V1_21)
 
 SHELL=/bin/bash
 # Rather arbitrary Bitnami style choice

--- a/tests/golden/test-simple-validate.pass.json
+++ b/tests/golden/test-simple-validate.pass.json
@@ -329,7 +329,7 @@
          }
       },
       {
-         "apiVersion": "networking.k8s.io/v1beta1",
+         "apiVersion": "networking.k8s.io/v1",
          "kind": "Ingress",
          "metadata": {
             "annotations": {
@@ -349,10 +349,16 @@
                      "paths": [
                         {
                            "backend": {
-                              "serviceName": "foo-svc",
-                              "servicePort": 80
+                              "service": {
+                                 "name": "foo-svc",
+                                 "port": {
+                                    "name": "http",
+                                    "number": 80
+                                 }
+                              }
                            },
-                           "path": "/"
+                           "path": "/",
+                           "pathType": "ImplementationSpecific"
                         }
                      ]
                   }
@@ -523,7 +529,7 @@
          }
       },
       {
-         "apiVersion": "networking.k8s.io/v1beta1",
+         "apiVersion": "networking.k8s.io/v1",
          "kind": "Ingress",
          "metadata": {
             "annotations": { },
@@ -541,9 +547,14 @@
                      "paths": [
                         {
                            "backend": {
-                              "serviceName": "service-a",
-                              "servicePort": "web"
-                           }
+                              "service": {
+                                 "name": "service-a",
+                                 "port": {
+                                    "name": "web"
+                                 }
+                              }
+                           },
+                           "pathType": "ImplementationSpecific"
                         }
                      ]
                   }
@@ -554,9 +565,14 @@
                      "paths": [
                         {
                            "backend": {
-                              "serviceName": "service-2",
-                              "servicePort": "web"
-                           }
+                              "service": {
+                                 "name": "service-2",
+                                 "port": {
+                                    "name": "web"
+                                 }
+                              }
+                           },
+                           "pathType": "ImplementationSpecific"
                         }
                      ]
                   }

--- a/tests/init-kube.jsonnet
+++ b/tests/init-kube.jsonnet
@@ -3,11 +3,15 @@ local kube = import "../kube.libsonnet";
 local crds = {
   // A simplified VPA CRD from https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
   vpa_crd: kube.CustomResourceDefinition("autoscaling.k8s.io", "v1beta1", "VerticalPodAutoscaler") {
+    metadata+: {
+      annotations: {
+        "api-approved.kubernetes.io": "https://github.com/kubernetes/kubernetes/pull/78458",
+      },
+    },
     spec+: {
-      versions+: [
-        { name: "v1beta1", served: true, storage: false },
-        { name: "v1beta2", served: true, storage: true },
-      ],
+      versions_+: {
+        v1beta2: self.v1beta1 { name: "v1beta2", storage: false },
+      },
     },
   },
   // Simplified cert-manager CRD from https://github.com/jetstack/cert-manager/blob/master/deploy/crds/crd-certificates.yaml,

--- a/tests/test-simple-validate.pass.jsonnet
+++ b/tests/test-simple-validate.pass.jsonnet
@@ -69,9 +69,14 @@ local stack = {
           host: "a.example.com",
           http: {
             paths: [{
+              pathType: "ImplementationSpecific",
               backend: {
-                serviceName: "service-a",
-                servicePort: "web",
+                service: {
+                  name: "service-a",
+                  port: {
+                    name: "web",
+                  },
+                },
               },
             }],
           },
@@ -80,9 +85,14 @@ local stack = {
           host: "b.example.com",
           http: {
             paths: [{
+              pathType: "ImplementationSpecific",
               backend: {
-                serviceName: "service-2",
-                servicePort: "web",
+                service: {
+                  name: "service-2",
+                  port: {
+                    name: "web",
+                  },
+                },
               },
             }],
           },


### PR DESCRIPTION
Fixes #60.

Support Kubernetes v1.22+ apiVersions deprecations, notably:

* `Ingress`:
  - use `apiVersion: networking.k8s.io/v1`
  - create (and populate) `service` field to each `path`
    (previously `serviceName` and `servicePort`)
  - `bitnami.libsonnet`: use `pathType: ImplementationSpecific`, which seems to be the
    most generic one

* `CustomResourceDefinition`:
  - use `apiVersion: apiextensions.k8s.io/v1`
  - create `versions` map with sensible defaults, including `spec`
    field, as commonly used fro CRs

Other changes:

* `tests/Makefile`: support (only) v1.19+

* `tests/init-kube.jsonnet`: CRD tweaks

FYI this is on top of #59.

**NOTE**: once merged upstream, would strongly recommend tagging it as `v1.19.0`, following the convention that tags' `<major>.<minor>` should express minimum required Kubernetes release.