### PR TITLE
Revert "[jjo] support Kubernetes v1.22+ apiVersions deprecations"

### DIFF
--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -52,13 +52,7 @@ local perCloudSvcSpec(cloud) = (
     host:: error "host required",
     target_svc:: error "target_svc required",
     // Default to single-service - override if you want something else.
-    paths:: [
-      {
-        path: "/",
-        backend: ing.target_svc.name_port,
-        pathType: "ImplementationSpecific",
-      },
-    ],
+    paths:: [{ path: "/", backend: ing.target_svc.name_port }],
     secretName:: "%s-cert" % [ing.metadata.name],
 
     // cert_provider can either be:

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -61,7 +61,7 @@
   // resource contructors will use kinds/versions/fields compatible at least with version:
   minKubeVersion: {
     major: 1,
-    minor: 19,
+    minor: 14,
     version: "%s.%s" % [self.major, self.minor],
   },
 
@@ -169,13 +169,8 @@
     ],
     // Useful in Ingress rules
     name_port:: {
-      service+: {
-        name: service.metadata.name,
-        port+: {
-          number: service.spec.ports[0].port,
-          [if std.objectHas(service.spec.ports[0], "name") then "name" else null]: service.spec.ports[0].name,
-        },
-      },
+      serviceName: service.metadata.name,
+      servicePort: service.spec.ports[0].port,
     },
 
     spec: {
@@ -583,7 +578,7 @@
     },
   },
 
-  Ingress(name): $._Object("networking.k8s.io/v1", "Ingress", name) {
+  Ingress(name): $._Object("networking.k8s.io/v1beta1", "Ingress", name) {
     spec: {},
 
     local rel_paths = [
@@ -602,7 +597,7 @@
 
   CustomResourceDefinition(group, version, kind): {
     local this = self,
-    apiVersion: "apiextensions.k8s.io/v1",
+    apiVersion: "apiextensions.k8s.io/v1beta1",
     kind: "CustomResourceDefinition",
     metadata+: {
       name: this.spec.names.plural + "." + this.spec.group,
@@ -610,24 +605,7 @@
     spec: {
       scope: "Namespaced",
       group: group,
-      versions_:: {
-        [version]: {
-          name: version,
-          served: true,
-          storage: true,
-          schema: {
-            openAPIV3Schema: {
-              type: "object",
-              properties: {
-                spec: {
-                  type: "object",
-                },
-              },
-            },
-          },
-        },
-      },
-      versions: $.mapToNamedList(self.versions_),
+      version: version,
       names: {
         kind: kind,
         singular: $.toLower(self.kind),
@@ -749,7 +727,7 @@
 
     target:: error "target required",
 
-    spec+: {
+    spec: {
       targetRef: $.CrossVersionObjectReference(vpa.target),
 
       updatePolicy: {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,7 @@ K3S_V1_21=v1.21.1-k3s1
 #
 # Kubernetes releases we cover with e2e testing,
 # we'll run `docker-compose` for each to below rancher/k3s versions (tags)
-E2E_K3S_VERSIONS=$(K3S_V1_19) $(K3S_V1_20) $(K3S_V1_21)
+E2E_K3S_VERSIONS=$(K3S_V1_14) $(K3S_V1_15) $(K3S_V1_16) $(K3S_V1_17) $(K3S_V1_18) $(K3S_V1_19) $(K3S_V1_20) $(K3S_V1_21)
 
 SHELL=/bin/bash
 # Rather arbitrary Bitnami style choice

--- a/tests/golden/test-simple-validate.pass.json
+++ b/tests/golden/test-simple-validate.pass.json
@@ -329,7 +329,7 @@
          }
       },
       {
-         "apiVersion": "networking.k8s.io/v1",
+         "apiVersion": "networking.k8s.io/v1beta1",
          "kind": "Ingress",
          "metadata": {
             "annotations": {
@@ -349,16 +349,10 @@
                      "paths": [
                         {
                            "backend": {
-                              "service": {
-                                 "name": "foo-svc",
-                                 "port": {
-                                    "name": "http",
-                                    "number": 80
-                                 }
-                              }
+                              "serviceName": "foo-svc",
+                              "servicePort": 80
                            },
-                           "path": "/",
-                           "pathType": "ImplementationSpecific"
+                           "path": "/"
                         }
                      ]
                   }
@@ -529,7 +523,7 @@
          }
       },
       {
-         "apiVersion": "networking.k8s.io/v1",
+         "apiVersion": "networking.k8s.io/v1beta1",
          "kind": "Ingress",
          "metadata": {
             "annotations": { },
@@ -547,14 +541,9 @@
                      "paths": [
                         {
                            "backend": {
-                              "service": {
-                                 "name": "service-a",
-                                 "port": {
-                                    "name": "web"
-                                 }
-                              }
-                           },
-                           "pathType": "ImplementationSpecific"
+                              "serviceName": "service-a",
+                              "servicePort": "web"
+                           }
                         }
                      ]
                   }
@@ -565,14 +554,9 @@
                      "paths": [
                         {
                            "backend": {
-                              "service": {
-                                 "name": "service-2",
-                                 "port": {
-                                    "name": "web"
-                                 }
-                              }
-                           },
-                           "pathType": "ImplementationSpecific"
+                              "serviceName": "service-2",
+                              "servicePort": "web"
+                           }
                         }
                      ]
                   }

--- a/tests/init-kube.jsonnet
+++ b/tests/init-kube.jsonnet
@@ -3,15 +3,11 @@ local kube = import "../kube.libsonnet";
 local crds = {
   // A simplified VPA CRD from https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
   vpa_crd: kube.CustomResourceDefinition("autoscaling.k8s.io", "v1beta1", "VerticalPodAutoscaler") {
-    metadata+: {
-      annotations: {
-        "api-approved.kubernetes.io": "https://github.com/kubernetes/kubernetes/pull/78458",
-      },
-    },
     spec+: {
-      versions_+: {
-        v1beta2: self.v1beta1 { name: "v1beta2", storage: false },
-      },
+      versions+: [
+        { name: "v1beta1", served: true, storage: false },
+        { name: "v1beta2", served: true, storage: true },
+      ],
     },
   },
   // Simplified cert-manager CRD from https://github.com/jetstack/cert-manager/blob/master/deploy/crds/crd-certificates.yaml,

--- a/tests/test-simple-validate.pass.jsonnet
+++ b/tests/test-simple-validate.pass.jsonnet
@@ -69,14 +69,9 @@ local stack = {
           host: "a.example.com",
           http: {
             paths: [{
-              pathType: "ImplementationSpecific",
               backend: {
-                service: {
-                  name: "service-a",
-                  port: {
-                    name: "web",
-                  },
-                },
+                serviceName: "service-a",
+                servicePort: "web",
               },
             }],
           },
@@ -85,14 +80,9 @@ local stack = {
           host: "b.example.com",
           http: {
             paths: [{
-              pathType: "ImplementationSpecific",
               backend: {
-                service: {
-                  name: "service-2",
-                  port: {
-                    name: "web",
-                  },
-                },
+                serviceName: "service-2",
+                servicePort: "web",
               },
             }],
           },


### PR DESCRIPTION
Reverts bitnami-labs/kube-libsonnet#61

It seems that #61 is going to cause some issues with our already existing Ingresses.
I've tested some new Ingresses in a 1.19 kops-based Kubernetes cluster and found-out the following:

```
....
[spec.rules[0].http.paths[0].backend: Invalid value: "": cannot set both port name & port number
And the Ingress resource I'm testing is:
```
```
...
  - host: <omitted>
    http:
      paths:
      - backend:
          service:
            name: <omitted>
            port:
              name: http
              number: 8080
        path: /
        pathType: ImplementationSpecific
```

Checking-out the official docs, it seems they also stopped adding the port number and name:

```
spec:
  rules:
  - http:
      paths:
      - path: /testpath
        pathType: Prefix
        backend:
          service:
            name: test
            port:
              number: 80
```              

[Ref.](https://kubernetes.io/docs/concepts/services-networking/ingress/)

cc/ @jjo 