### PR TITLE
[jjo] support Kubernetes v1.22+ apiVersions deprecations (round2)

### DIFF
--- a/bitnami.libsonnet
+++ b/bitnami.libsonnet
@@ -52,7 +52,13 @@ local perCloudSvcSpec(cloud) = (
     host:: error "host required",
     target_svc:: error "target_svc required",
     // Default to single-service - override if you want something else.
-    paths:: [{ path: "/", backend: ing.target_svc.name_port }],
+    paths:: [
+      {
+        path: "/",
+        backend: ing.target_svc.name_port,
+        pathType: "ImplementationSpecific",
+      },
+    ],
     secretName:: "%s-cert" % [ing.metadata.name],
 
     // cert_provider can either be:

--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -619,8 +619,9 @@
       scope: "Namespaced",
       group: group,
       versions_:: {
-        [version]: {
-          name: version,
+        // Create an opinionated default_spec for the version, easy to override by the user,
+        // specially if they had several versions to derived from the same "skeleton".
+        default_spec:: {
           served: true,
           storage: true,
           schema: {
@@ -634,6 +635,7 @@
             },
           },
         },
+        [version]: self.default_spec,
       },
       versions: $.mapToNamedList(self.versions_),
       names: {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,7 @@ K3S_V1_21=v1.21.1-k3s1
 #
 # Kubernetes releases we cover with e2e testing,
 # we'll run `docker-compose` for each to below rancher/k3s versions (tags)
-E2E_K3S_VERSIONS=$(K3S_V1_14) $(K3S_V1_15) $(K3S_V1_16) $(K3S_V1_17) $(K3S_V1_18) $(K3S_V1_19) $(K3S_V1_20) $(K3S_V1_21)
+E2E_K3S_VERSIONS=$(K3S_V1_19) $(K3S_V1_20) $(K3S_V1_21)
 
 SHELL=/bin/bash
 # Rather arbitrary Bitnami style choice

--- a/tests/golden/test-Ingress-2ndport.pass.json
+++ b/tests/golden/test-Ingress-2ndport.pass.json
@@ -1,0 +1,173 @@
+{
+   "deploy": {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+         "annotations": { },
+         "labels": {
+            "name": "test-Ingress-fail-deploy"
+         },
+         "name": "test-Ingress-fail-deploy"
+      },
+      "spec": {
+         "minReadySeconds": 30,
+         "replicas": 1,
+         "revisionHistoryLimit": 10,
+         "selector": {
+            "matchLabels": {
+               "name": "test-Ingress-fail-deploy"
+            }
+         },
+         "strategy": {
+            "rollingUpdate": {
+               "maxSurge": "25%",
+               "maxUnavailable": "25%"
+            },
+            "type": "RollingUpdate"
+         },
+         "template": {
+            "metadata": {
+               "annotations": { },
+               "labels": {
+                  "name": "test-Ingress-fail-deploy"
+               }
+            },
+            "spec": {
+               "containers": [
+                  {
+                     "args": [ ],
+                     "env": [ ],
+                     "image": "nginx:1.12",
+                     "imagePullPolicy": "IfNotPresent",
+                     "name": "test-Ingress-fail",
+                     "ports": [
+                        {
+                           "containerPort": 80,
+                           "name": "http"
+                        },
+                        {
+                           "containerPort": 9099,
+                           "name": "metrics"
+                        }
+                     ],
+                     "stdin": false,
+                     "tty": false,
+                     "volumeMounts": [ ]
+                  }
+               ],
+               "imagePullSecrets": [ ],
+               "initContainers": [ ],
+               "terminationGracePeriodSeconds": 30,
+               "volumes": [ ]
+            }
+         }
+      }
+   },
+   "ingress": {
+      "apiVersion": "networking.k8s.io/v1",
+      "kind": "Ingress",
+      "metadata": {
+         "annotations": {
+            "cert-manager.io/cluster-issuer": "letsencrypt-prod-dns"
+         },
+         "labels": {
+            "name": "test-Ingress-fail-ingress"
+         },
+         "name": "test-Ingress-fail-ingress"
+      },
+      "spec": {
+         "rules": [
+            {
+               "host": "foo.g.dev.bitnami.net",
+               "http": {
+                  "paths": [
+                     {
+                        "backend": {
+                           "service": {
+                              "name": "test-Ingress-fail-svc",
+                              "port": {
+                                 "name": "metrics"
+                              }
+                           }
+                        },
+                        "path": "/",
+                        "pathType": "ImplementationSpecific"
+                     }
+                  ]
+               }
+            }
+         ],
+         "tls": [
+            {
+               "hosts": [
+                  "foo.g.dev.bitnami.net"
+               ],
+               "secretName": "test-Ingress-fail-ingress-cert"
+            }
+         ]
+      }
+   },
+   "pod": {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+         "annotations": { },
+         "labels": {
+            "name": "test-Ingress-fail-pod"
+         },
+         "name": "test-Ingress-fail-pod"
+      },
+      "spec": {
+         "containers": [
+            {
+               "args": [ ],
+               "env": [ ],
+               "image": "nginx:1.12",
+               "imagePullPolicy": "IfNotPresent",
+               "name": "test-Ingress-fail",
+               "ports": [
+                  {
+                     "containerPort": 80,
+                     "name": "http"
+                  },
+                  {
+                     "containerPort": 9099,
+                     "name": "metrics"
+                  }
+               ],
+               "stdin": false,
+               "tty": false,
+               "volumeMounts": [ ]
+            }
+         ],
+         "imagePullSecrets": [ ],
+         "initContainers": [ ],
+         "terminationGracePeriodSeconds": 30,
+         "volumes": [ ]
+      }
+   },
+   "service": {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+         "annotations": { },
+         "labels": {
+            "name": "test-Ingress-fail-svc"
+         },
+         "name": "test-Ingress-fail-svc"
+      },
+      "spec": {
+         "ports": [
+            {
+               "name": "http",
+               "port": 80,
+               "targetPort": 80
+            }
+         ],
+         "selector": {
+            "name": "test-Ingress-fail-deploy"
+         },
+         "type": "ClusterIP"
+      }
+   }
+}

--- a/tests/golden/test-Ingress-2ndport.pass.json
+++ b/tests/golden/test-Ingress-2ndport.pass.json
@@ -5,9 +5,9 @@
       "metadata": {
          "annotations": { },
          "labels": {
-            "name": "test-Ingress-fail-deploy"
+            "name": "test-Ingress-pass-deploy"
          },
-         "name": "test-Ingress-fail-deploy"
+         "name": "test-Ingress-pass-deploy"
       },
       "spec": {
          "minReadySeconds": 30,
@@ -15,7 +15,7 @@
          "revisionHistoryLimit": 10,
          "selector": {
             "matchLabels": {
-               "name": "test-Ingress-fail-deploy"
+               "name": "test-Ingress-pass-deploy"
             }
          },
          "strategy": {
@@ -29,7 +29,7 @@
             "metadata": {
                "annotations": { },
                "labels": {
-                  "name": "test-Ingress-fail-deploy"
+                  "name": "test-Ingress-pass-deploy"
                }
             },
             "spec": {
@@ -39,7 +39,7 @@
                      "env": [ ],
                      "image": "nginx:1.12",
                      "imagePullPolicy": "IfNotPresent",
-                     "name": "test-Ingress-fail",
+                     "name": "test-Ingress-pass",
                      "ports": [
                         {
                            "containerPort": 80,
@@ -71,9 +71,9 @@
             "cert-manager.io/cluster-issuer": "letsencrypt-prod-dns"
          },
          "labels": {
-            "name": "test-Ingress-fail-ingress"
+            "name": "test-Ingress-pass-ingress"
          },
-         "name": "test-Ingress-fail-ingress"
+         "name": "test-Ingress-pass-ingress"
       },
       "spec": {
          "rules": [
@@ -84,7 +84,7 @@
                      {
                         "backend": {
                            "service": {
-                              "name": "test-Ingress-fail-svc",
+                              "name": "test-Ingress-pass-svc",
                               "port": {
                                  "name": "metrics"
                               }
@@ -102,7 +102,7 @@
                "hosts": [
                   "foo.g.dev.bitnami.net"
                ],
-               "secretName": "test-Ingress-fail-ingress-cert"
+               "secretName": "test-Ingress-pass-ingress-cert"
             }
          ]
       }
@@ -113,9 +113,9 @@
       "metadata": {
          "annotations": { },
          "labels": {
-            "name": "test-Ingress-fail-pod"
+            "name": "test-Ingress-pass-pod"
          },
-         "name": "test-Ingress-fail-pod"
+         "name": "test-Ingress-pass-pod"
       },
       "spec": {
          "containers": [
@@ -124,7 +124,7 @@
                "env": [ ],
                "image": "nginx:1.12",
                "imagePullPolicy": "IfNotPresent",
-               "name": "test-Ingress-fail",
+               "name": "test-Ingress-pass",
                "ports": [
                   {
                      "containerPort": 80,
@@ -152,9 +152,9 @@
       "metadata": {
          "annotations": { },
          "labels": {
-            "name": "test-Ingress-fail-svc"
+            "name": "test-Ingress-pass-svc"
          },
-         "name": "test-Ingress-fail-svc"
+         "name": "test-Ingress-pass-svc"
       },
       "spec": {
          "ports": [
@@ -165,7 +165,7 @@
             }
          ],
          "selector": {
-            "name": "test-Ingress-fail-deploy"
+            "name": "test-Ingress-pass-deploy"
          },
          "type": "ClusterIP"
       }

--- a/tests/golden/test-Ingress-port_num_only.pass.json
+++ b/tests/golden/test-Ingress-port_num_only.pass.json
@@ -5,9 +5,9 @@
       "metadata": {
          "annotations": { },
          "labels": {
-            "name": "test-Ingress-fail-deploy"
+            "name": "test-Ingress-pass-deploy"
          },
-         "name": "test-Ingress-fail-deploy"
+         "name": "test-Ingress-pass-deploy"
       },
       "spec": {
          "minReadySeconds": 30,
@@ -15,7 +15,7 @@
          "revisionHistoryLimit": 10,
          "selector": {
             "matchLabels": {
-               "name": "test-Ingress-fail-deploy"
+               "name": "test-Ingress-pass-deploy"
             }
          },
          "strategy": {
@@ -29,7 +29,7 @@
             "metadata": {
                "annotations": { },
                "labels": {
-                  "name": "test-Ingress-fail-deploy"
+                  "name": "test-Ingress-pass-deploy"
                }
             },
             "spec": {
@@ -39,7 +39,7 @@
                      "env": [ ],
                      "image": "nginx:1.12",
                      "imagePullPolicy": "IfNotPresent",
-                     "name": "test-Ingress-fail",
+                     "name": "test-Ingress-pass",
                      "ports": [
                         {
                            "containerPort": 80,
@@ -71,9 +71,9 @@
             "cert-manager.io/cluster-issuer": "letsencrypt-prod-dns"
          },
          "labels": {
-            "name": "test-Ingress-fail-ingress"
+            "name": "test-Ingress-pass-ingress"
          },
-         "name": "test-Ingress-fail-ingress"
+         "name": "test-Ingress-pass-ingress"
       },
       "spec": {
          "rules": [
@@ -84,7 +84,7 @@
                      {
                         "backend": {
                            "service": {
-                              "name": "test-Ingress-fail-svc",
+                              "name": "test-Ingress-pass-svc",
                               "port": {
                                  "number": 4242
                               }
@@ -102,7 +102,7 @@
                "hosts": [
                   "foo.g.dev.bitnami.net"
                ],
-               "secretName": "test-Ingress-fail-ingress-cert"
+               "secretName": "test-Ingress-pass-ingress-cert"
             }
          ]
       }
@@ -113,9 +113,9 @@
       "metadata": {
          "annotations": { },
          "labels": {
-            "name": "test-Ingress-fail-pod"
+            "name": "test-Ingress-pass-pod"
          },
-         "name": "test-Ingress-fail-pod"
+         "name": "test-Ingress-pass-pod"
       },
       "spec": {
          "containers": [
@@ -124,7 +124,7 @@
                "env": [ ],
                "image": "nginx:1.12",
                "imagePullPolicy": "IfNotPresent",
-               "name": "test-Ingress-fail",
+               "name": "test-Ingress-pass",
                "ports": [
                   {
                      "containerPort": 80,
@@ -152,9 +152,9 @@
       "metadata": {
          "annotations": { },
          "labels": {
-            "name": "test-Ingress-fail-svc"
+            "name": "test-Ingress-pass-svc"
          },
-         "name": "test-Ingress-fail-svc"
+         "name": "test-Ingress-pass-svc"
       },
       "spec": {
          "ports": [
@@ -165,7 +165,7 @@
             }
          ],
          "selector": {
-            "name": "test-Ingress-fail-deploy"
+            "name": "test-Ingress-pass-deploy"
          },
          "type": "ClusterIP"
       }

--- a/tests/golden/test-Ingress-port_num_only.pass.json
+++ b/tests/golden/test-Ingress-port_num_only.pass.json
@@ -1,0 +1,173 @@
+{
+   "deploy": {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+         "annotations": { },
+         "labels": {
+            "name": "test-Ingress-fail-deploy"
+         },
+         "name": "test-Ingress-fail-deploy"
+      },
+      "spec": {
+         "minReadySeconds": 30,
+         "replicas": 1,
+         "revisionHistoryLimit": 10,
+         "selector": {
+            "matchLabels": {
+               "name": "test-Ingress-fail-deploy"
+            }
+         },
+         "strategy": {
+            "rollingUpdate": {
+               "maxSurge": "25%",
+               "maxUnavailable": "25%"
+            },
+            "type": "RollingUpdate"
+         },
+         "template": {
+            "metadata": {
+               "annotations": { },
+               "labels": {
+                  "name": "test-Ingress-fail-deploy"
+               }
+            },
+            "spec": {
+               "containers": [
+                  {
+                     "args": [ ],
+                     "env": [ ],
+                     "image": "nginx:1.12",
+                     "imagePullPolicy": "IfNotPresent",
+                     "name": "test-Ingress-fail",
+                     "ports": [
+                        {
+                           "containerPort": 80,
+                           "name": "http"
+                        },
+                        {
+                           "containerPort": 9099,
+                           "name": "metrics"
+                        }
+                     ],
+                     "stdin": false,
+                     "tty": false,
+                     "volumeMounts": [ ]
+                  }
+               ],
+               "imagePullSecrets": [ ],
+               "initContainers": [ ],
+               "terminationGracePeriodSeconds": 30,
+               "volumes": [ ]
+            }
+         }
+      }
+   },
+   "ingress": {
+      "apiVersion": "networking.k8s.io/v1",
+      "kind": "Ingress",
+      "metadata": {
+         "annotations": {
+            "cert-manager.io/cluster-issuer": "letsencrypt-prod-dns"
+         },
+         "labels": {
+            "name": "test-Ingress-fail-ingress"
+         },
+         "name": "test-Ingress-fail-ingress"
+      },
+      "spec": {
+         "rules": [
+            {
+               "host": "foo.g.dev.bitnami.net",
+               "http": {
+                  "paths": [
+                     {
+                        "backend": {
+                           "service": {
+                              "name": "test-Ingress-fail-svc",
+                              "port": {
+                                 "number": 4242
+                              }
+                           }
+                        },
+                        "path": "/",
+                        "pathType": "ImplementationSpecific"
+                     }
+                  ]
+               }
+            }
+         ],
+         "tls": [
+            {
+               "hosts": [
+                  "foo.g.dev.bitnami.net"
+               ],
+               "secretName": "test-Ingress-fail-ingress-cert"
+            }
+         ]
+      }
+   },
+   "pod": {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+         "annotations": { },
+         "labels": {
+            "name": "test-Ingress-fail-pod"
+         },
+         "name": "test-Ingress-fail-pod"
+      },
+      "spec": {
+         "containers": [
+            {
+               "args": [ ],
+               "env": [ ],
+               "image": "nginx:1.12",
+               "imagePullPolicy": "IfNotPresent",
+               "name": "test-Ingress-fail",
+               "ports": [
+                  {
+                     "containerPort": 80,
+                     "name": "http"
+                  },
+                  {
+                     "containerPort": 9099,
+                     "name": "metrics"
+                  }
+               ],
+               "stdin": false,
+               "tty": false,
+               "volumeMounts": [ ]
+            }
+         ],
+         "imagePullSecrets": [ ],
+         "initContainers": [ ],
+         "terminationGracePeriodSeconds": 30,
+         "volumes": [ ]
+      }
+   },
+   "service": {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+         "annotations": { },
+         "labels": {
+            "name": "test-Ingress-fail-svc"
+         },
+         "name": "test-Ingress-fail-svc"
+      },
+      "spec": {
+         "ports": [
+            {
+               "name": "http",
+               "port": 80,
+               "targetPort": 80
+            }
+         ],
+         "selector": {
+            "name": "test-Ingress-fail-deploy"
+         },
+         "type": "ClusterIP"
+      }
+   }
+}

--- a/tests/golden/test-simple-validate.pass.json
+++ b/tests/golden/test-simple-validate.pass.json
@@ -352,8 +352,7 @@
                               "service": {
                                  "name": "foo-svc",
                                  "port": {
-                                    "name": "http",
-                                    "number": 80
+                                    "name": "http"
                                  }
                               }
                            },

--- a/tests/golden/test-simple-validate.pass.json
+++ b/tests/golden/test-simple-validate.pass.json
@@ -329,7 +329,7 @@
          }
       },
       {
-         "apiVersion": "networking.k8s.io/v1beta1",
+         "apiVersion": "networking.k8s.io/v1",
          "kind": "Ingress",
          "metadata": {
             "annotations": {
@@ -349,10 +349,16 @@
                      "paths": [
                         {
                            "backend": {
-                              "serviceName": "foo-svc",
-                              "servicePort": 80
+                              "service": {
+                                 "name": "foo-svc",
+                                 "port": {
+                                    "name": "http",
+                                    "number": 80
+                                 }
+                              }
                            },
-                           "path": "/"
+                           "path": "/",
+                           "pathType": "ImplementationSpecific"
                         }
                      ]
                   }
@@ -523,7 +529,7 @@
          }
       },
       {
-         "apiVersion": "networking.k8s.io/v1beta1",
+         "apiVersion": "networking.k8s.io/v1",
          "kind": "Ingress",
          "metadata": {
             "annotations": { },
@@ -541,9 +547,14 @@
                      "paths": [
                         {
                            "backend": {
-                              "serviceName": "service-a",
-                              "servicePort": "web"
-                           }
+                              "service": {
+                                 "name": "service-a",
+                                 "port": {
+                                    "name": "web"
+                                 }
+                              }
+                           },
+                           "pathType": "ImplementationSpecific"
                         }
                      ]
                   }
@@ -554,9 +565,14 @@
                      "paths": [
                         {
                            "backend": {
-                              "serviceName": "service-2",
-                              "servicePort": "web"
-                           }
+                              "service": {
+                                 "name": "service-2",
+                                 "port": {
+                                    "name": "web"
+                                 }
+                              }
+                           },
+                           "pathType": "ImplementationSpecific"
                         }
                      ]
                   }

--- a/tests/init-kube.jsonnet
+++ b/tests/init-kube.jsonnet
@@ -10,7 +10,7 @@ local crds = {
     },
     spec+: {
       versions_+: {
-        v1beta2: self.v1beta1 { name: "v1beta2", storage: false },
+        v1beta2: self.default_spec { storage: false },
       },
     },
   },

--- a/tests/init-kube.jsonnet
+++ b/tests/init-kube.jsonnet
@@ -3,11 +3,15 @@ local kube = import "../kube.libsonnet";
 local crds = {
   // A simplified VPA CRD from https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
   vpa_crd: kube.CustomResourceDefinition("autoscaling.k8s.io", "v1beta1", "VerticalPodAutoscaler") {
+    metadata+: {
+      annotations: {
+        "api-approved.kubernetes.io": "https://github.com/kubernetes/kubernetes/pull/78458",
+      },
+    },
     spec+: {
-      versions+: [
-        { name: "v1beta1", served: true, storage: false },
-        { name: "v1beta2", served: true, storage: true },
-      ],
+      versions_+: {
+        v1beta2: self.v1beta1 { name: "v1beta2", storage: false },
+      },
     },
   },
   // Simplified cert-manager CRD from https://github.com/jetstack/cert-manager/blob/master/deploy/crds/crd-certificates.yaml,

--- a/tests/test-Ingress-2ndport.pass.jsonnet
+++ b/tests/test-Ingress-2ndport.pass.jsonnet
@@ -2,7 +2,7 @@ local bitnami = import "../bitnami.libsonnet";
 local kube = import "../kube.libsonnet";
 
 local stack = {
-  name:: "test-Ingress-fail",
+  name:: "test-Ingress-pass",
   pod: kube.Pod($.name + "-pod") {
     spec+: {
       containers_+: {
@@ -29,6 +29,7 @@ local stack = {
     local this = self,
     target_pod: $.deploy.spec.template,
     name_port+:: {
+      // Override default_port to 2nd port instead of 1st (default),
       default_port:: this.target_pod.spec.containers[0].ports[1],
     },
   },
@@ -39,5 +40,6 @@ local stack = {
 };
 
 stack {
+  // Assert we got 2nd port dubbed "metrics" for Ingress
   assert (stack.ingress.spec.rules[0].http.paths[0].backend.service.port == { name: "metrics" }),
 }

--- a/tests/test-Ingress-2ndport.pass.jsonnet
+++ b/tests/test-Ingress-2ndport.pass.jsonnet
@@ -39,5 +39,5 @@ local stack = {
 };
 
 stack {
-  assert (stack.ingress.spec.rules[0].http.paths[0].backend.service.port.name == "metrics"),
+  assert (stack.ingress.spec.rules[0].http.paths[0].backend.service.port == { name: "metrics" }),
 }

--- a/tests/test-Ingress-2ndport.pass.jsonnet
+++ b/tests/test-Ingress-2ndport.pass.jsonnet
@@ -1,0 +1,43 @@
+local bitnami = import "../bitnami.libsonnet";
+local kube = import "../kube.libsonnet";
+
+local stack = {
+  name:: "test-Ingress-fail",
+  pod: kube.Pod($.name + "-pod") {
+    spec+: {
+      containers_+: {
+        foo_cont: kube.Container($.name) {
+          image: "nginx:1.12",
+          ports_+: {
+            http: { containerPort: 80 },
+            metrics: { containerPort: 9099 },
+          },
+        },
+      },
+    },
+  },
+  deploy: kube.Deployment($.name + "-deploy") {
+    local this = self,
+    spec+: {
+      template+: {
+        spec+: $.pod.spec {
+        },
+      },
+    },
+  },
+  service: kube.Service($.name + "-svc") {
+    local this = self,
+    target_pod: $.deploy.spec.template,
+    name_port+:: {
+      default_port:: this.target_pod.spec.containers[0].ports[1],
+    },
+  },
+  ingress: bitnami.Ingress($.name + "-ingress") {
+    host: "foo.g.dev.bitnami.net",
+    target_svc: $.service,
+  },
+};
+
+stack {
+  assert (stack.ingress.spec.rules[0].http.paths[0].backend.service.port.name == "metrics"),
+}

--- a/tests/test-Ingress-name_port.fail.jsonnet
+++ b/tests/test-Ingress-name_port.fail.jsonnet
@@ -1,0 +1,43 @@
+local bitnami = import "../bitnami.libsonnet";
+local kube = import "../kube.libsonnet";
+
+local stack = {
+  name:: "test-Ingress-fail",
+  pod: kube.Pod($.name + "-pod") {
+    spec+: {
+      containers_+: {
+        foo_cont: kube.Container($.name) {
+          image: "nginx:1.12",
+          ports_+: {
+            http: { containerPort: 80 },
+            metrics: { containerPort: 9099 },
+          },
+        },
+      },
+    },
+  },
+  deploy: kube.Deployment($.name + "-deploy") {
+    local this = self,
+    spec+: {
+      template+: {
+        spec+: $.pod.spec {
+        },
+      },
+    },
+  },
+  service: kube.Service($.name + "-svc") {
+    local this = self,
+    target_pod: $.deploy.spec.template,
+    name_port+:: {
+      // Force failing from having `name` _and_ `number` rendered for the
+      // ingress spec (via name_port, see kube.libsonnet)
+      port_spec+:: { number: 4242 },
+    },
+  },
+  ingress: bitnami.Ingress($.name + "-ingress") {
+    host: "foo.g.dev.bitnami.net",
+    target_svc: $.service,
+  },
+};
+
+stack

--- a/tests/test-Ingress-port_num_only.pass.jsonnet
+++ b/tests/test-Ingress-port_num_only.pass.jsonnet
@@ -1,0 +1,43 @@
+local bitnami = import "../bitnami.libsonnet";
+local kube = import "../kube.libsonnet";
+
+local stack = {
+  name:: "test-Ingress-fail",
+  pod: kube.Pod($.name + "-pod") {
+    spec+: {
+      containers_+: {
+        foo_cont: kube.Container($.name) {
+          image: "nginx:1.12",
+          ports_+: {
+            http: { containerPort: 80 },
+            metrics: { containerPort: 9099 },
+          },
+        },
+      },
+    },
+  },
+  deploy: kube.Deployment($.name + "-deploy") {
+    local this = self,
+    spec+: {
+      template+: {
+        spec+: $.pod.spec {
+        },
+      },
+    },
+  },
+  service: kube.Service($.name + "-svc") {
+    local this = self,
+    target_pod: $.deploy.spec.template,
+    name_port+:: {
+      port_spec:: { number: 4242 },
+    },
+  },
+  ingress: bitnami.Ingress($.name + "-ingress") {
+    host: "foo.g.dev.bitnami.net",
+    target_svc: $.service,
+  },
+};
+
+stack {
+  assert (stack.ingress.spec.rules[0].http.paths[0].backend.service.port.number == 4242),
+}

--- a/tests/test-Ingress-port_num_only.pass.jsonnet
+++ b/tests/test-Ingress-port_num_only.pass.jsonnet
@@ -39,5 +39,5 @@ local stack = {
 };
 
 stack {
-  assert (stack.ingress.spec.rules[0].http.paths[0].backend.service.port.number == 4242),
+  assert (stack.ingress.spec.rules[0].http.paths[0].backend.service.port == { number: 4242 }),
 }

--- a/tests/test-Ingress-port_num_only.pass.jsonnet
+++ b/tests/test-Ingress-port_num_only.pass.jsonnet
@@ -2,7 +2,7 @@ local bitnami = import "../bitnami.libsonnet";
 local kube = import "../kube.libsonnet";
 
 local stack = {
-  name:: "test-Ingress-fail",
+  name:: "test-Ingress-pass",
   pod: kube.Pod($.name + "-pod") {
     spec+: {
       containers_+: {
@@ -29,6 +29,7 @@ local stack = {
     local this = self,
     target_pod: $.deploy.spec.template,
     name_port+:: {
+      // Force port to _only_ be below number (note no `+::` construct)
       port_spec:: { number: 4242 },
     },
   },
@@ -39,5 +40,6 @@ local stack = {
 };
 
 stack {
+  // Assert we got expected port number for Ingress
   assert (stack.ingress.spec.rules[0].http.paths[0].backend.service.port == { number: 4242 }),
 }

--- a/tests/test-simple-validate.pass.jsonnet
+++ b/tests/test-simple-validate.pass.jsonnet
@@ -69,9 +69,14 @@ local stack = {
           host: "a.example.com",
           http: {
             paths: [{
+              pathType: "ImplementationSpecific",
               backend: {
-                serviceName: "service-a",
-                servicePort: "web",
+                service: {
+                  name: "service-a",
+                  port: {
+                    name: "web",
+                  },
+                },
               },
             }],
           },
@@ -80,9 +85,14 @@ local stack = {
           host: "b.example.com",
           http: {
             paths: [{
+              pathType: "ImplementationSpecific",
               backend: {
-                serviceName: "service-2",
-                servicePort: "web",
+                service: {
+                  name: "service-2",
+                  port: {
+                    name: "web",
+                  },
+                },
               },
             }],
           },


### PR DESCRIPTION
Fixes #60, after also fixing PR #61 issues.

Support Kubernetes v1.22+ apiVersions deprecations, notably:

* `Ingress`:
  - use `apiVersion: networking.k8s.io/v1`
  - create (and populate) `service` field to each `path`
    (previously `serviceName` and `servicePort`)
  - `bitnami.libsonnet`: use `pathType: ImplementationSpecific`, which seems to be the
    most generic one
  - add Ingress service `name` and `number` mutual exclusion logic and test cases

* `CustomResourceDefinition`:
  - use `apiVersion: apiextensions.k8s.io/v1`
  - create `versions` map with sensible defaults, including `spec`
    field, as commonly used fro CRs

Other changes:

* `tests/Makefile`: support (only) v1.19+

* `tests/init-kube.jsonnet`: CRD tweaks


