### PR TITLE
remove deprecated annotation from pvc manifest

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -218,12 +218,6 @@
     storageClass:: null,
     storage:: error "storage required",
 
-    metadata+: if pvc.storageClass != null then {
-      annotations+: {
-        "volume.beta.kubernetes.io/storage-class": pvc.storageClass,
-      },
-    } else {},
-
     spec: {
       resources: {
         requests: {


### PR DESCRIPTION
Adding an annotation is deprecated and will no longer be available in the later version of K8s, hence it's better to remove it https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class

`storageClassName` attribute is enough to set the name of the Storage Class, so this annotation is unnecessary

PS: force-push was for getting commits signed with my right GPG keys
