### PR TITLE
Remove StatefulSet replicas assert

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -519,7 +519,6 @@
       ],
 
       replicas: 1,
-      assert (!$._assert) || self.replicas >= 1,
     },
   },
 


### PR DESCRIPTION
There sometimes is a justified use for setting replicas to 0, and I
don't really see any technical reasoning for this assert.