### PR TITLE
update storageclass API to v1

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -208,7 +208,7 @@
     persistentVolumeClaim: { claimName: pvc.metadata.name },
   },
 
-  StorageClass(name): $._Object("storage.k8s.io/v1beta1", "StorageClass", name) {
+  StorageClass(name): $._Object("storage.k8s.io/v1", "StorageClass", name) {
     provisioner: error "provisioner required",
   },
 


### PR DESCRIPTION
v1beta1 is deprecated in K8s 1.19 as part of this PR https://github.com/kubernetes/kubernetes/pull/90671

We are updating the StorageClass object to use the correct API