### PR TITLE
remove empty curly brackets from namespace manifest

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -143,8 +143,7 @@
     items: $.objectValues(self.items_),
   },
 
-  Namespace(name): $._Object("v1", "Namespace", name) {
-  },
+  Namespace(name): $._Object("v1", "Namespace", name),
 
   Endpoints(name): $._Object("v1", "Endpoints", name) {
     Ip(addr):: { ip: addr },
@@ -647,8 +646,7 @@
     },
   },
 
-  ServiceAccount(name): $._Object("v1", "ServiceAccount", name) {
-  },
+  ServiceAccount(name): $._Object("v1", "ServiceAccount", name),
 
   Role(name): $._Object("rbac.authorization.k8s.io/v1", "Role", name) {
     rules: [],


### PR DESCRIPTION
seems like having an empty curly brackets is breaking the styling in IDEs like IntelliJ (haven't tested in VS Code)

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/19990016/140669060-e6e6069e-0ea1-4ed7-b3eb-3eebc89399f6.png">


I get this error message:

```
<binaryop>, JsonnetTokenType.DOT, JsonnetTokenType.IN, JsonnetTokenType.L_BRACKET, JsonnetTokenType.L_CURLY or JsonnetTokenType.L_PAREN expected, got ','
```

This also breaks the "Go to Declaration" when we're using this an object from this library. Removing the curly brackets fixes the issue