### PR TITLE
kube-libsonnet: remove deprecated api.

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -208,7 +208,7 @@
     persistentVolumeClaim: { claimName: pvc.metadata.name },
   },
 
-  StorageClass(name): $._Object("storage.k8s.io/v1beta1", "StorageClass", name) {
+  StorageClass(name): $._Object("storage.k8s.io/v1", "StorageClass", name) {
     provisioner: error "provisioner required",
   },
 


### PR DESCRIPTION
The storage.k8s.io/v1beta1 API version of CSIDriver, CSINode, StorageClass,
and VolumeAttachment is no longer served as of v1.22.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#storage-resources-v122

Signed-off-by: Lionel Hubaut <lionel.hubaut@tessares.net>