### PR TITLE
Deployment: remove replicas=1

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -451,8 +451,6 @@
 
       // NB: Regular k8s default is to keep all revisions
       revisionHistoryLimit: 10,
-
-      replicas: 1,
     },
   },
 


### PR DESCRIPTION
# Description

This PR removes the `replicas: 1` inside the Deployment object.

# Motivation
For Horizontal Pod Autoscaler to work properly with gitops systems such as ArgoCD, FluxCD, Deployment objects shouldnt' have `replicas` set. The default `replicas` is 1 so this is safe to be removed.
Also it appears that it is not easy to remove a field in jsonnet once it is set, so it is better to just not set it.

# References
* Linked issue: https://github.com/bitnami-labs/kube-libsonnet/issues/58
* ArgoCD: https://argo-cd.readthedocs.io/en/stable/user-guide/best_practices/#leaving-room-for-imperativeness
* FluxCD: https://argo-cd.readthedocs.io/en/stable/user-guide/best_practices/#leaving-room-for-imperativeness
* Remove a field from jsonnet issue: https://github.com/google/jsonnet/issues/312