### PR TITLE
Update apiextensions.k8s.io/v1 test for v1.22

### DIFF
--- a/tests/golden/init-kube.json
+++ b/tests/golden/init-kube.json
@@ -1,6 +1,6 @@
 {
    "vpa_crd": {
-      "apiVersion": "apiextensions.k8s.io/v1beta1",
+      "apiVersion": "apiextensions.k8s.io/v1",
       "kind": "CustomResourceDefinition",
       "metadata": {
          "name": "verticalpodautoscalers.autoscaling.k8s.io"


### PR DESCRIPTION
The apiextensions.k8s.io/v1beta1 API version of CustomResourceDefinition is no longer served as of v1.22. Migrate manifests and API clients to use the apiextensions.k8s.io/v1 API version, available since v1.16.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122