### PR TITLE
Change CronJob API Version to batch/v1 and PodDisruptionBudget to policy/v1

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -265,7 +265,7 @@
     assert (!$._assert) || (!self.tty || self.stdin) : "tty=true requires stdin=true",
   },
 
-  PodDisruptionBudget(name): $._Object("policy/v1beta1", "PodDisruptionBudget", name) {
+  PodDisruptionBudget(name): $._Object("policy/v1", "PodDisruptionBudget", name) {
     local this = self,
     target_pod:: error "target_pod required",
     spec: {
@@ -528,7 +528,7 @@
     },
   },
 
-  CronJob(name): $._Object("batch/v1beta1", "CronJob", name) {
+  CronJob(name): $._Object("batch/v1", "CronJob", name) {
     local cronjob = self,
 
     spec: {

--- a/tests/golden/test-simple-validate.pass.json
+++ b/tests/golden/test-simple-validate.pass.json
@@ -17,7 +17,7 @@
          }
       },
       {
-         "apiVersion": "batch/v1beta1",
+         "apiVersion": "batch/v1",
          "kind": "CronJob",
          "metadata": {
             "annotations": { },
@@ -200,7 +200,7 @@
          }
       },
       {
-         "apiVersion": "policy/v1beta1",
+         "apiVersion": "policy/v1",
          "kind": "PodDisruptionBudget",
          "metadata": {
             "annotations": { },


### PR DESCRIPTION
PodDisruptionBudget policy/v1beta1 is removed in K8s v1.25
CronJob batch/v1beta1 is removed in K8s v1.25

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25