### PR TITLE
cronjob: batch/v1 stable since k8s 1.21

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -528,7 +528,7 @@
     },
   },
 
-  CronJob(name): $._Object("batch/v1beta1", "CronJob", name) {
+  CronJob(name): $._Object("batch/v1", "CronJob", name) {
     local cronjob = self,
 
     spec: {


### PR DESCRIPTION
* The api is stable since k8s 1.21 and batch/v1beta1 is no longer served: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125

Signed-off-by: Lionel Hubaut <lionel.hubaut@tessares.net>