### PR TITLE
Update PodDisruptionBudget to `policy/v1`

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -265,7 +265,7 @@
     assert (!$._assert) || (!self.tty || self.stdin) : "tty=true requires stdin=true",
   },
 
-  PodDisruptionBudget(name): $._Object("policy/v1beta1", "PodDisruptionBudget", name) {
+  PodDisruptionBudget(name): $._Object("policy/v1", "PodDisruptionBudget", name) {
     local this = self,
     target_pod:: error "target_pod required",
     spec: {


### PR DESCRIPTION
`policy/v1beta1` PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+