### PR TITLE
Upgrade HPA to v2

### DIFF
--- a/kube.libsonnet
+++ b/kube.libsonnet
@@ -461,7 +461,7 @@
     name: target.metadata.name,
   },
 
-  HorizontalPodAutoscaler(name): $._Object("autoscaling/v1", "HorizontalPodAutoscaler", name) {
+  HorizontalPodAutoscaler(name): $._Object("autoscaling/v2", "HorizontalPodAutoscaler", name) {
     local hpa = self,
 
     target:: error "target required",


### PR DESCRIPTION
Fixes: autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+